### PR TITLE
Phab/t85573

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@
 // For Map. Not used in the fast path.
 require("es6-shim");
 
+// a global variable holding the ID the next created node should have
+var nextNodeId = 0;
+
 /*
  * A node in the lookup graph.
  *
@@ -11,7 +14,9 @@ require("es6-shim");
 function Node () {
     // The value for a path ending on this node. Public property.
     this.value = null;
-
+    // this node's ID
+    this.id = nextNodeId++;
+    
     // Internal properties.
     this._map = {};
     this._name = null;
@@ -240,6 +245,17 @@ Router.prototype._lookup = function route(path, node) {
 Router.prototype.lookup = function route(path) {
     path = normalizePath(path);
     return this._lookup(path, this._root);
+};
+
+/**
+ * Reports the number of nodes created by the router. Note that
+ * this is the total number of created nodes; if some are deleted,
+ * this number is not decreased.
+ * 
+ * @return {Number} the total number of created nodes
+ */
+Router.prototype.noNodes = function () {
+    return nextNodeId;
 };
 
 module.exports = Router;

--- a/index.js
+++ b/index.js
@@ -361,4 +361,9 @@ Router.prototype.noNodes = function () {
     return nextNodeId;
 };
 
-module.exports = Router;
+module.exports = {
+    Router: Router,
+    URI: URI,
+    Node: Node
+};
+

--- a/index.js
+++ b/index.js
@@ -189,6 +189,10 @@ function URI(uri, params) {
  * @return {URI} this URI object
  */
 URI.prototype.bind = function (params) {
+    if (!params || params.constructor !== Object) {
+        // wrong params format
+        return this;
+    }
     // look only for parameter keys which match
     // variables in the URI
     this._uri.forEach(function (item) {

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,7 @@ var expectations = {
 
 var domains = ['en.wikipedia.org','de.wikipedia.org'];
 
-var router = new Router();
+var router = new Router.Router();
 specs.forEach(function(spec) {
     domains.forEach(function(domain) {
         router.addSpec(spec, '/{domain:' + domain + '}/v1');

--- a/test/index.js
+++ b/test/index.js
@@ -123,7 +123,7 @@ var expectations = {
     '/en.wikipedia.org/v1//': null
 };
 
-var domains = ['en.wikipedia.org','de.wikipedia.org'];
+var domains = ['en.wikipedia.org','de.wikipedia.org', 'fr.wikipedia.org', 'es.wikipedia.org'];
 
 var router = new Router.Router();
 specs.forEach(function(spec) {
@@ -140,5 +140,12 @@ describe('swagger-router', function() {
             deepEqual(router.lookup(key), val);
         });
     });
+    
+    it('node count', function () {
+        // we should have 24 nodes + 2 for each test domain (domain/v1 prefix)
+        // 24 nodes = 22 path nodes in the test spec + the spec root node + the root node
+        deepEqual(router.noNodes(), 24 + 2 * domains.length);
+    });
+    
 });
 


### PR DESCRIPTION
This PR addresses [T85573](https://phabricator.wikimedia.org/T85573). It brings two changes to the router:
1. _URI objects_: URI's can now be built using the URI class, to which one can optionally pass in values for variables defined in the path and, thus, bind them to the values.
2. _Spec tree sharing_: When a new spec is passed to `addSpec()`, its full tree is constructed and remembered. Later, when a prefix is called for the same spec, the prefix' tree path is created and its endpoint is connected to the spec's tree's nodes.

Note that for this first iteration, the code assumes there will be no changes in the routing tree. Also, `addSpec()` still conforms to the same `(prefix, spec)` signature found in the tests.
