### PR TITLE
Enable modifiers in URI

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ function parsePattern (pattern) {
         // {domain:en.wikipedia.org}
         var m = /^{([+\/])?([a-zA-Z0-9_]+)(?::([^}]+))?}$/.exec(bit);
         if (m) {
-            if (m[1]) {
-                throw new Error("Modifiers are not yet implemented: " + pattern);
-            }
+///            if (m[1]) {
+///                throw new Error("Modifiers are not yet implemented: " + pattern);
+///            }
             return {
                 modifier: m[1],
                 name: m[2],
@@ -259,11 +259,13 @@ URI.prototype.toString = function () {
                 // there is a known value for this variable,
                 // so use it
                 this._str += '/' + encodeURIComponent(item.pattern);
-            } else if (item.modifer) {
+            } else if (item.modifier) {
                 // we are dealing with a modifier, and there
-                // seems to be no value, so simply ignore the
-                // component
-                this._str += '';
+                // seems to be no value, so check the modifier type
+                if (item.modifier === '+') {
+                    // we need to add a slash for a +
+                    this._str += '/';
+                }
             } else {
                 // we have a variable component, but no value,
                 // so let's just return the variable name

--- a/test/index.js
+++ b/test/index.js
@@ -189,17 +189,29 @@ describe('URI', function() {
         deepEqual(uri.toString(), '/foo%2Fbar/path/to/something');
     });
 
-    it('{/patterns}', function() {
-        try {
-            var uri = new URI('/{domain:some}/path/to{/optionalPath}');
-            uri = new URI(uri);
-            uri.bind({domain: 'foo'});
-            deepEqual(uri.toString(), '/foo/path/to{/optionalPath}');
-        } catch (e) {
-            if (!/Modifiers are not yet implemented/.test(e.message)) {
-                throw e;
-            }
-        }
+    it('{/patterns} empty', function() {
+        var uri = new URI('/{domain:some}/path/to{/optionalPath}');
+        uri = new URI(uri);
+        uri.bind({domain: 'foo'});
+        deepEqual(uri.toString(), '/foo/path/to');
+    });
+
+    it('{/patterns} bound', function() {
+        var uri = new URI('/{domain:some}/path/to{/optionalPath}');
+        uri = new URI(uri);
+        uri.bind({optionalPath: 'foo'});
+        deepEqual(uri.toString(), '/some/path/to/foo');
+    });
+
+    it('{+patterns} empty', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}');
+        deepEqual(uri.toString(), '/some/path/to/');
+    });
+
+    it('{+patterns} bound', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}');
+        uri.bind({rest: 'foo'});
+        deepEqual(uri.toString(), '/some/path/to/foo');
     });
 
     it('decoding / encoding', function() {


### PR DESCRIPTION
This PR enables proper support for modifiers in the URI class and adds some tests for it. Note, however, that is more of a work-in-progress PR.

This patch allows us to pass 12 tests in restbase (due to the fact that there are {+rest} URI patterns in /sys/table) :)
