### PR TITLE
Minor fix in lookup()

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,6 +499,8 @@ Router.prototype._lookup = function route(path, node) {
 Router.prototype.lookup = function route(path) {
     if (!path || path.constructor !== URI) {
         path = normalizePath(path);
+    } else if (path.constructor === URI) {
+        path = path.path;
     }
     var res = this._lookup(path, this._root);
     if (res) {


### PR DESCRIPTION
`_lookup()` expects to be given an array. However, we may actually give it a `URI` object. If so, make sure we pass in its `path` property, not the object itself
