### PR TITLE
Add fullPattern / simplePattern serialization modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,14 +88,14 @@ function parsePattern (pattern, isPattern) {
  *  - `params` {object} mutable. Parameter object.
  *  - `path` {array} immutable.
  */
-function URI(uri, params, isPattern) {
+function URI(uri, params, asPattern) {
     this.params = params || {};
     if (uri && uri.constructor === URI) {
         // this.path is considered immutable, so can be shared with other URI
         // instances
         this.path = uri.path;
     } else if (uri && (uri.constructor === String || Array.isArray(uri))) {
-        this.path = parsePattern(uri, isPattern);
+        this.path = parsePattern(uri, asPattern);
     } else if (uri !== '') {
         throw new Error('Invalid path passed into URI constructor: ' + uri);
     }
@@ -105,10 +105,10 @@ function URI(uri, params, isPattern) {
  * Builds and returns the full, bounded string path for this URI object
  *
  * @return {String} the complete path of this URI object
- * @param {Boolean} asPattern Whether to serialize to a pattern [optional]
+ * @param {string} format Either 'simplePattern' or 'fullPattern'. [optional]
  * @return {string} URI path
  */
-URI.prototype.toString = function (asPattern) {
+URI.prototype.toString = function (format) {
     var uriStr = '';
     for (var i = 0; i < this.path.length; i++) {
         var segment = this.path[i];
@@ -119,7 +119,7 @@ URI.prototype.toString = function (asPattern) {
             }
 
             if (segmentValue !== undefined) {
-                if (!asPattern || !segment.name) {
+                if (!format || format === 'simplePattern' || !segment.name) {
                     // Normal mode
                     uriStr += '/' + encodeURIComponent(segmentValue);
                 } else {
@@ -127,8 +127,10 @@ URI.prototype.toString = function (asPattern) {
                         + encodeURIComponent(segment.name) + ':'
                         + encodeURIComponent(segmentValue) + '}';
                 }
-            } else if (asPattern) {
-                uriStr += '{' + segment.modifier
+            } else if (format && !segment.modifier) {
+                uriStr += '/{' + encodeURIComponent(segment.name) + '}';
+            } else if (format) {
+                uriStr += '{' + (segment.modifier || '')
                     + encodeURIComponent(segment.name)
                     + '}';
             } else {

--- a/test/index.js
+++ b/test/index.js
@@ -336,6 +336,13 @@ describe('URI', function() {
         deepEqual(uri.toString(), '/test.com/v1');
     });
 
+    it('should serialize with "simplePattern" and "fullPattern" formats', function() {
+        var uri = new URI('/{domain:test.com}/v1/{title}{/foo}{+bar}', {}, true);
+        deepEqual(uri.toString(), '/test.com/v1');
+        deepEqual(uri.toString('simplePattern'), '/test.com/v1/{title}{/foo}{+bar}');
+        deepEqual(uri.toString('fullPattern'), '/{domain:test.com}/v1/{title}{/foo}{+bar}');
+    });
+
     it('check for a prefix path', function() {
         var uri = new URI('/{domain:test.com}/v1/page/{title}', {}, true);
         deepEqual(uri.startsWith('/test.com/v1/page'), true);


### PR DESCRIPTION
- fullPattern corresponds to the previous boolean 'asPattern' flag
- simplePattern directly expands to a value (if set), but also preserves
  optional parameters as patterns. Patterns don't include value or regexp
  matches.
