### PR TITLE
Cleanup & speed-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -204,7 +204,7 @@ var expectations = {
     '/en.wikipedia.org/v1/optional/': {
         params: {
             domain: 'en.wikipedia.org',
-            _ls: ['**']
+            _ls: []
         },
         value: null
     },


### PR DESCRIPTION
- Split parsePattern into simple parsePath & complex parsePattern
- Pre-allocate arrays in expand
- Simplify Node.getChild
- Fix a bug in the _ls code
