### PR TITLE
Support full URLs with protocol etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
     - "0.10"
-    - "0.11"
+    - "0.12"
+    - "iojs"
 

--- a/index.js
+++ b/index.js
@@ -203,12 +203,15 @@ URI.prototype.expand = function(params) {
                     }
                 }
             }
-            res[i] = segmentValue;
+            res[i] = segmentValue + ''; // coerce segments to string
         } else {
             res[i] = segment;
         }
     }
-    return new URI(res);
+    var uri = new URI(res);
+    // FIXME: handle this in the constructor!
+    uri.urlObj = this.urlObj;
+    return uri;
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -305,6 +305,11 @@ describe('URI', function() {
         deepEqual(uri.toString(), '/some/path/to/foo');
     });
 
+    it('{/patterns} dynamic expand', function() {
+        var uri = new URI('/{domain:some}/path/to{/optionalPath}', {}, true);
+        deepEqual(uri.expand({optionalPath: 'foo'}).toString(), '/some/path/to/foo');
+    });
+
     it('{+patterns} empty', function() {
         var uri = new URI('/{domain:some}/path/to/{+rest}', {}, true);
         deepEqual(uri.toString(), '/some/path/to/');
@@ -314,6 +319,11 @@ describe('URI', function() {
         var uri = new URI('/{domain:some}/path/to/{+rest}',
                 {rest: 'foo'}, true);
         deepEqual(uri.toString(), '/some/path/to/foo');
+    });
+
+    it('{+patterns} dynamic expand', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
+        deepEqual(uri.expand({rest: 'foo'}).toString(), '/some/path/to/foo');
     });
 
     it('decoding / encoding', function() {
@@ -357,5 +367,19 @@ describe('URI', function() {
     it('check for a prefix path', function() {
         var uri = new URI('/{domain:test.com}/v1/page/{title}', {}, true);
         deepEqual(uri.startsWith('/test.com/v1/page'), true);
+    });
+
+    it('handle protocols', function() {
+        var uri = new URI('https://test.com/v1/page/title');
+        deepEqual(uri.urlObj.protocol, 'https:');
+        deepEqual(uri.path[0], 'v1');
+        deepEqual(uri.toString(), 'https://test.com/v1/page/title');
+    });
+
+    it('handle protocols & patterns', function() {
+        var uri = new URI('https://test.com/v1/page/{title}',
+                {title: 'testTitle'}, true);
+        deepEqual(uri.startsWith('/v1/page'), true);
+        deepEqual(uri.toString(), 'https://test.com/v1/page/testTitle');
     });
 });


### PR DESCRIPTION
So far we only supported paths, but not full URLs with protocol, host &
authentication details. We do however need that capability for backend request
templating, so this patch adds it.

The other change introduced by this patch is the option of passing parameters
into the expand() method, rather than updating the property before calling
`.expand()`. This will be cleaner in URI templating situations.
