### PR TITLE
Fixed a bug with string-based templates

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -171,7 +171,11 @@ function replaceComplexTemplates(part, subSpec, globals) {
             if (!/^[\$'"]/.test(subSpec) && !/[\{\[\(]/.test(subSpec)) {
                 // Simple local reference
                 // XXX: won't handle nested references
-                return '$.request.' + part + '.' + subSpec;
+                if (part) {
+                    return '$.request.' + part + '.' + subSpec;
+                } else {
+                    return '$.' + subSpec;
+                }
             } else {
                 var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, part);
                 if (tAssemblyTemplates.length > 1) {
@@ -200,6 +204,14 @@ function replaceComplexTemplates(part, subSpec, globals) {
     return subSpec;
 }
 
+function _cloneSpec(spec) {
+    if (typeof spec === 'string') {
+        return spec;
+    } else {
+        return Object.assign({}, spec);
+    }
+}
+
 /**
  * Creates and compiles a new Template object using the provided JSON spec
  *
@@ -209,24 +221,27 @@ function replaceComplexTemplates(part, subSpec, globals) {
  *              fields that couldn't be resolved from original request would be ignored.
  */
 function Template(spec) {
-    spec = Object.assign({}, spec);
     var self = this;
     var globals = Object.assign({}, globalMethods);
+    spec = _cloneSpec(spec);
     globals._i = 0;
-    Object.keys(spec).forEach(function(part) {
-        if (part === 'uri') {
-            globals.uri = createURIResolver(spec);
-            spec.uri = '$$.uri($context)';
-        } else if (part === 'method') {
-            spec.method = "'" + (spec.method || 'get') + "'";
-        } else {
-            spec[part] = replaceComplexTemplates(part, spec[part], globals);
-        }
-    });
 
-    var completeTAssemblyTemplate;
-    completeTAssemblyTemplate = expressionCompiler.parse(spec);
+    if (typeof spec === 'string') {
+        spec = replaceComplexTemplates(undefined, spec, globals);
+    } else {
+        Object.keys(spec).forEach(function(part) {
+            if (part === 'uri') {
+                globals.uri = createURIResolver(spec);
+                spec.uri = '$$.uri($context)';
+            } else if (part === 'method') {
+                spec.method = "'" + (spec.method || 'get') + "'";
+            } else {
+                spec[part] = replaceComplexTemplates(part, spec[part], globals);
+            }
+        });
+    }
 
+    var completeTAssemblyTemplate = expressionCompiler.parse(spec);
     var res;
     var callback = function(bit) {
         if (res === undefined) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "bluebird": "2.8.2",
-    "core-js": "^1.1.4",
+    "core-js": "^1.2.2",
     "js-yaml": "^3.4.2",
     "tassembly": "^0.2.0",
     "template-expression-compiler": "^0.1.0"

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -255,4 +255,56 @@ describe('Request template', function() {
             extra: 'extra'
         });
     });
+
+    it('should support string templates', function() {
+        var template = new Template('{$.request}');
+        var request = {
+            method: 'get',
+            uri: 'test.com',
+            body: {
+                field: 'value'
+            }
+        };
+        var result = template.expand({ request: request });
+        assert.deepEqual(result, request);
+    });
+
+    it('should support short notation in string templates', function() {
+        var template = new Template('{request}');
+        var request = {
+            method: 'get',
+            uri: 'test.com',
+            body: {
+                field: 'value'
+            }
+        };
+        var result = template.expand({ request: request });
+        assert.deepEqual(result, request);
+    });
+
+    it('should support short nested notation in string templates', function() {
+        var template = new Template('{request.method}');
+        var request = {
+            method: 'get',
+            uri: 'test.com',
+            body: {
+                field: 'value'
+            }
+        };
+        var result = template.expand({ request: request });
+        assert.deepEqual(result, 'get');
+    });
+
+    it('should support short nested notation with brackets in string templates', function() {
+        var template = new Template('{request[$.request.body.field]}');
+        var request = {
+            method: 'get',
+            uri: 'test.com',
+            body: {
+                field: 'method'
+            }
+        };
+        var result = template.expand({ request: request });
+        assert.deepEqual(result, 'get');
+    });
 });


### PR DESCRIPTION
Very recently, a [a new version of core-js](https://www.npmjs.com/package/core-js) released, which changes (improves) a way how `Object.assign` works. Because of that, one of the RESTBase tests started failing: in `handlerTemplate` tests we use a request template with a string template, not object. This should be supported by `reqTemplate` library, but we didn't have explicit tests for that feature, and it got broken by recent template lib refactoring and want's noticed, because of a bug in `core-js` package and because the feature wasn't used in production.

This PR adds back support for string templates, and adds tests for this feature.
