### PR TITLE
Fixed support for {+pattern} templates

### DIFF
--- a/lib/uri.js
+++ b/lib/uri.js
@@ -118,10 +118,6 @@ URI.prototype.expand = function(params) {
                 if (segmentValue === undefined) {
                     if (segment.modifier) {
                         // Okay to end the URI here
-                        // Pop over-allocated entries
-                        while (res[res.length - 1] === undefined) {
-                            res.pop();
-                        }
                         return new URI(res);
                     } else {
                         throw new Error('URI.expand: parameter ' + segment.name + ' not defined!');

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -108,7 +108,7 @@ URI.prototype.expand = function(params) {
     if (!params) {
         params = this.params;
     }
-    var res = new Array(this.path.length);
+    var res = [];
     for (var i = 0; i < this.path.length; i++) {
         var segment = this.path[i];
         if (segment && segment.constructor === Object) {
@@ -128,9 +128,13 @@ URI.prototype.expand = function(params) {
                     }
                 }
             }
-            res[i] = segmentValue + ''; // coerce segments to string
+            if (Array.isArray(segmentValue)) {
+                res = res.concat(segmentValue);
+            } else {
+                res.push(segmentValue + ''); // coerce segments to string)
+            }
         } else {
-            res[i] = segment;
+            res.push(segment);
         }
     }
     var uri = new URI(res);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -157,13 +157,21 @@ describe('Request template', function() {
             request: {
                 params: {
                     domain: 'en.wikipedia.org',
-                    path: 'test1/test2/test3'
+                    path: [
+                        'test1',
+                        'test2',
+                        'test3'
+                    ]
                 }
             }
         });
         assert.deepEqual(result.uri,
         new URI('http://en.wikipedia.org/path1/{+path}', {}, true).expand({
-            path: 'test1/test2/test3'
+            path: [
+                'test1',
+                'test2',
+                'test3'
+            ]
         }));
     });
 

--- a/test/features/uri.js
+++ b/test/features/uri.js
@@ -53,6 +53,11 @@ describe('URI', function() {
         deepEqual(uri.expand({rest: 'foo'}).toString(), '/some/path/to/foo');
     });
 
+    it('{+patterns} dynamic expand with array', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
+        deepEqual(uri.expand({rest: ['foo', 'bar']}).toString(), '/some/path/to/foo/bar');
+    });
+
     it('decoding / encoding', function() {
         var uri = new URI('/{domain:some}/a%2Fb/to/100%/%FF', {domain: 'foo/bar'}, true);
         // Note how the invalid % encoding is fixed up to %25


### PR DESCRIPTION
The `router.lookup` method returns `params` for `{+rest}` templates as a path array (which is correct), so for `/test/{+rest}` uri spec and `/test/one/two/three` uri, the `request.params` would be:

``` javascript
{
    rest: ['one', 'two', 'three']
}
```

So, when this is used to expand a URI template with `{rest}`, the Array is converted to a string by adding an empty string, so effectively, if we expand something like `/expanded/{rest}` with params from above, we will get `/expanded/one%2Ctwo%2Cthree`, which will fail to route (`%2C` === `,`).

So, for arrays in params, used in path segments, we should join them using `/` as a delimiter, and concatenated with a resulting path array.
