### PR TITLE
Better support {+pattern} template expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ router.lookup(['']); // equivalent: router.lookup('/');
 URIs are represented by `URI` class, which supports a limited set of features
 from [URI Template RFC 6570](http://tools.ietf.org/html/rfc6570). 
 
-# Supported URI template expressions:
+### Supported URI template expressions:
 - Simple string expression `{pattern}` - on expansion, looks up a variable named `pattern` in params
   and substitutes its pct-encoded value. On matching, matches a single element in the path, and
   sets `params.pattern` to the path element value. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swagger 2 router
 [![Build
-Status](https://travis-ci.org/gwicke/swagger-router.svg?branch=master)](https://travis-ci.org/gwicke/swagger-router)
+Status](https://travis-ci.org/wikimedia/swagger-router.svg?branch=master)](https://travis-ci.org/wikimedia/swagger-router)
 
 ## Features
 - `O(path element)` lookup complexity, monomorphic design with simple fast path.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ router.lookup(['']); // equivalent: router.lookup('/');
 */
 
 ```
+## URI templating
+
+URIs are represented by `URI` class, which supports a limited set of features
+from [URI Template RFC 6570](http://tools.ietf.org/html/rfc6570). 
+
+# Supported URI template expressions:
+- Simple string expression `{pattern}` - on expansion, looks up a variable named `pattern` in params
+  and substitutes its pct-encoded value. On matching, matches a single element in the path, and
+  sets `params.pattern` to the path element value. 
+- Restricted expression `{+pattern}` - on expansion, works the same way as simple expression, but doesn't
+  pct-encode [reserved characters](http://tools.ietf.org/html/rfc3986#section-2.2) and ptc-triplets.
+  On matching, matches the whole subpath and writes it's value to `params.pattern` variable.
+- Optional expression `{/pattern}` - works the same way as simple expression, but on matching the path 
+  element is optional.
+- Fixed expression `{pattern:value}` - on matching, matches only uris with path element equal to `value`,
+  and exports `value` as `params.pattern` variable. On expansion, substitutes `value`.
+
+These features are optimised and available with `URI.expand(params)` method. Additional features
+are available with request templating.
 
 ## Request templating
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -52,10 +52,10 @@ Node.prototype.getChild = function(segment, params) {
                 if (!res && this._children['**']) {
                     res = this._children['**'];
                     // Build up an array for ** matches ({+foo})
-                    if (!Array.isArray(params[res._paramName])) {
-                        params[res._paramName] = [segment];
+                    if (params[res._paramName]) {
+                        params[res._paramName] += '/' + segment;
                     } else {
-                        params[res._paramName].push(segment);
+                        params[res._paramName] = segment;
                     }
                     // We are done.
                     return res;

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -84,8 +84,7 @@ URI.prototype.toString = function(options) {
                 uriStr += '/{' + encodeURIComponent(segment.name) + '}';
             } else if (options.format) {
                 uriStr += '{' + (segment.modifier || '')
-                    + encodeURIComponent(segment.name)
-                    + '}';
+                    + encodeURIComponent(segment.name) + '}';
             } else {
                 if (segment.modifier === '+') {
                     // Add trailing slash

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -6,7 +6,7 @@ var utils = require('./utils');
  * Represents a URI object which can optionally contain and
  * bind optional variables encountered in the URI string
  *
- * @param {String|URI} uri the URI path or object to create a new URI from
+ * @param {String|URI|Array} uri the URI path or object to create a new URI from
  * @param {Object} params the values for variables encountered in the URI path (optional)
  * @param {boolean} asPattern Whether to parse the URI as a pattern (optional)
  * @return {URI} URI object. Public properties:
@@ -14,8 +14,12 @@ var utils = require('./utils');
  *  - `path` {array} immutable.
  */
 function URI(uri, params, asPattern) {
+    // Initialise all fields to make an object monomorphic
     this.params = params || {};
     this.urlObj = null;
+    this.path = [];
+    this._pathMetadata = {};
+
     if (uri && uri.constructor === URI) {
         this.urlObj = uri.urlObj;
         // this.path is considered immutable, so can be shared with other URI
@@ -73,15 +77,15 @@ URI.prototype.toString = function(options) {
                     }
                 } else {
                     uriStr += '/{' + (segment.modifier || '')
-                    + encodeURIComponent(segment.name) + ':'
-                    + encodeURIComponent(segmentValue) + '}';
+                        + encodeURIComponent(segment.name) + ':'
+                        + encodeURIComponent(segmentValue) + '}';
                 }
             } else if (options.format && !segment.modifier) {
                 uriStr += '/{' + encodeURIComponent(segment.name) + '}';
             } else if (options.format) {
                 uriStr += '{' + (segment.modifier || '')
-                + encodeURIComponent(segment.name)
-                + '}';
+                    + encodeURIComponent(segment.name)
+                    + '}';
             } else {
                 if (segment.modifier === '+') {
                     // Add trailing slash
@@ -90,6 +94,10 @@ URI.prototype.toString = function(options) {
                 // Omit optional segment & return
                 return uriStr;
             }
+        } else if (this._pathMetadata
+                && this._pathMetadata[i]
+                && this._pathMetadata[i] === '+') {
+            uriStr += '/' + utils.encodeReserved(segment);
         } else {
             uriStr += '/' + encodeURIComponent(segment);
         }
@@ -109,6 +117,8 @@ URI.prototype.expand = function(params) {
         params = this.params;
     }
     var res = [];
+    var pathMetadata = {};
+    var uri;
     for (var i = 0; i < this.path.length; i++) {
         var segment = this.path[i];
         if (segment && segment.constructor === Object) {
@@ -118,23 +128,33 @@ URI.prototype.expand = function(params) {
                 if (segmentValue === undefined) {
                     if (segment.modifier) {
                         // Okay to end the URI here
-                        return new URI(res);
+                        uri = new URI(res);
+                        uri._pathMetadata = pathMetadata;
+                        return uri;
                     } else {
                         throw new Error('URI.expand: parameter ' + segment.name + ' not defined!');
                     }
                 }
             }
-            if (Array.isArray(segmentValue)) {
-                res = res.concat(segmentValue);
+
+            if (segment.modifier === '+') {
+                // Res will become a path array, so we must split path elements
+                var splitPath = ('' + segmentValue).split('/');
+                res = res.concat(splitPath);
+                for (var j = res.length - 1; j < res.length - 1 + splitPath.length; j++) {
+                    pathMetadata[j] = '+';
+                }
             } else {
-                res.push(segmentValue + ''); // coerce segments to string)
+                res.push('' + segmentValue);
             }
         } else {
             res.push(segment);
         }
     }
-    var uri = new URI(res);
+
+    uri = new URI(res);
     // FIXME: handle this in the constructor!
+    uri._pathMetadata = pathMetadata;
     uri.urlObj = this.urlObj;
     return uri;
 };

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -138,9 +138,10 @@ URI.prototype.expand = function(params) {
 
             if (segment.modifier === '+') {
                 // Res will become a path array, so we must split path elements
-                var splitPath = ('' + segmentValue).split('/');
-                res = res.concat(splitPath);
-                for (var j = res.length - 1; j < res.length - 1 + splitPath.length; j++) {
+                var oldResLen = res.length;
+                res = res.concat(('' + segmentValue).split('/'));
+                // Set up metadata for all path elements under {+} template
+                for (var j = oldResLen; j < res.length; j++) {
                     pathMetadata[j] = '+';
                 }
             } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,4 +75,44 @@ utils.parsePath = function(path, isPattern) {
     }
 };
 
+var reservedEncoderExpression
+        = /%(21|23|24|26|27|28|29|2A|2B|2C|2F|3A|3B|3D|3F|40|5B|5D)/ig;
+var reservedEncoderMappings = {
+    // gen-delims
+    '%3A': ':',
+    '%2F': '/',
+    '%3F': '?',
+    '%23': '#',
+    '%5B': '[',
+    '%5D': ']',
+    '%40': '@',
+    // sub-delims
+    '%21': '!',
+    '%24': '$',
+    '%26': '&',
+    '%27': '\'',
+    '%28': '(',
+    '%29': ')',
+    '%2A': '*',
+    '%2B': '+',
+    '%2C': ',',
+    '%3B': ';',
+    '%3D': '='
+};
+
+/**
+ * RFC6570 compliant encoder for `reserved` expansion - encodes a URI component
+ * while preserving reserved characters (http://tools.ietf.org/html/rfc3986#section-2.2)
+ * and pct-encoded triplets
+ *
+ * @param string - a string to encode
+ * @return {String} an encoded string
+ */
+utils.encodeReserved = function(string) {
+    string = decodeURIComponent('' + string);
+    return encodeURIComponent(string).replace(reservedEncoderExpression, function(c) {
+        return reservedEncoderMappings[c];
+    });
+};
+
 module.exports = utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,44 +75,19 @@ utils.parsePath = function(path, isPattern) {
     }
 };
 
-var reservedEncoderExpression
-        = /%(3A|2F|3F|23|5B|5D|40|21|24|26|27|28|29|2A|2B|2C|3B|3D)/ig;
-var reservedEncoderMappings = {
-    // gen-delims
-    '%3A': ':',
-    '%2F': '/',
-    '%3F': '?',
-    '%23': '#',
-    '%5B': '[',
-    '%5D': ']',
-    '%40': '@',
-    // sub-delims
-    '%21': '!',
-    '%24': '$',
-    '%26': '&',
-    '%27': '\'',
-    '%28': '(',
-    '%29': ')',
-    '%2A': '*',
-    '%2B': '+',
-    '%2C': ',',
-    '%3B': ';',
-    '%3D': '='
-};
-
 /**
  * RFC6570 compliant encoder for `reserved` expansion - encodes a URI component
- * while preserving reserved characters (http://tools.ietf.org/html/rfc3986#section-2.2)
- * and pct-encoded triplets
+ * while preserving reserved & unreserved characters
+ * (http://tools.ietf.org/html/rfc3986#section-2.2) and pct-encoded triplets
  *
  * @param string - a string to encode
  * @return {String} an encoded string
  */
 utils.encodeReserved = function(string) {
-    string = decodeURIComponent('' + string);
-    return encodeURIComponent(string).replace(reservedEncoderExpression, function(c) {
-        return reservedEncoderMappings[c];
-    });
+    return encodeURI(string)
+        .replace(/%5B/gi, '[')
+        .replace(/%5D/gi, ']')
+        .replace(/%25/g, '%');
 };
 
 module.exports = utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ utils.parsePath = function(path, isPattern) {
 };
 
 var reservedEncoderExpression
-        = /%(21|23|24|26|27|28|29|2A|2B|2C|2F|3A|3B|3D|3F|40|5B|5D)/ig;
+        = /%(3A|2F|3F|23|5B|5D|40|21|24|26|27|28|29|2A|2B|2C|3B|3D)/ig;
 var reservedEncoderMappings = {
     // gen-delims
     '%3A': ':',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/router.js
+++ b/test/features/router.js
@@ -166,7 +166,7 @@ var expectations = {
             domain: 'en.wikipedia.org',
             optional: 'optional',
             path: 'path',
-            segments: ['segments'],
+            segments: 'segments',
         },
         permissions: []
     },
@@ -176,7 +176,7 @@ var expectations = {
             domain: 'en.wikipedia.org',
             optional: 'optional',
             path: 'path',
-            segments: ['segments','a'],
+            segments: 'segments/a',
         },
         permissions: []
     },
@@ -186,7 +186,7 @@ var expectations = {
             domain: 'en.wikipedia.org',
             optional: 'optional',
             path: 'path',
-            segments: ['segments','a','b'],
+            segments: 'segments/a/b',
         },
         permissions: []
     },
@@ -228,7 +228,7 @@ var expectations = {
         value: '/optional/{+path}',
         params: {
             domain: 'en.wikipedia.org',
-            path: ['path']
+            path: 'path'
         },
         permissions: []
     },
@@ -236,7 +236,7 @@ var expectations = {
         value: '/optional/{+path}',
         params: {
             domain: 'en.wikipedia.org',
-            path: ['path','bits']
+            path: 'path/bits'
         },
         permissions: []
     },

--- a/test/features/uri.js
+++ b/test/features/uri.js
@@ -55,7 +55,17 @@ describe('URI', function() {
 
     it('{+patterns} dynamic expand with array', function() {
         var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
-        deepEqual(uri.expand({rest: ['foo', 'bar']}).toString(), '/some/path/to/foo/bar');
+        deepEqual(uri.expand({rest: ['foo', 'bar']}).toString(), '/some/path/to/foo,bar');
+    });
+
+    it('{+patterns} dynamic expand with subpath', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
+        deepEqual(uri.expand({rest: 'foo/bar'}).toString(), '/some/path/to/foo/bar');
+    });
+
+    it('{+patterns} dynamic expand with reserved chars', function() {
+        var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
+        deepEqual(uri.expand({rest: 'foo/bar?test#a=$'}).toString(), '/some/path/to/foo/bar?test#a=$');
     });
 
     it('decoding / encoding', function() {

--- a/test/features/uri.js
+++ b/test/features/uri.js
@@ -65,7 +65,7 @@ describe('URI', function() {
 
     it('{+patterns} dynamic expand with reserved chars', function() {
         var uri = new URI('/{domain:some}/path/to/{+rest}',{}, true);
-        deepEqual(uri.expand({rest: 'foo/bar?test#a=$'}).toString(), '/some/path/to/foo/bar?test#a=$');
+        deepEqual(uri.expand({rest: 'foo$bar/bar?test#a=$'}).toString(), '/some/path/to/foo$bar/bar?test#a=$');
     });
 
     it('decoding / encoding', function() {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -8,7 +8,7 @@ var utils = require('../../lib/utils');
 
 describe('utils tests', function() {
     it('should correctly encode reserved expansion', function() {
-        deepEqual(utils.encodeReserved('ä:/?#[]@!$&\'()*+,;=%2f'),
-            '%C3%A4:/?#[]@!$&\'()*+,;=/');
+        deepEqual(utils.encodeReserved('ä:/?#[]@!$&\'()*+,;=%2f%20'),
+            '%C3%A4:/?#[]@!$&\'()*+,;=%2f%20');
     });
 });

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,14 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var deepEqual = require('../utils/assert').deepEqual;
+var utils = require('../../lib/utils');
+
+describe('utils tests', function() {
+    it('should correctly encode reserved expansion', function() {
+        deepEqual(utils.encodeReserved('ä:/?#[]@!$&\'()*+,;=%2f'),
+            '%C3%A4:/?#[]@!$&\'()*+,;=/');
+    });
+});


### PR DESCRIPTION
[RFC](http://tools.ietf.org/html/rfc6570#page-22) clearly describes `{+pattern}` template expansion, which we did in a completely wrong way. Changes:
- On the matching side, when matching `{+pattern}` templates, don't split up the path to an array
- On expansion part, if `{+pattern}` template is found, split up the subpath as we are building a `path` array. This is needed to allow correct matching on subsequent requests in a chain.
- When stringifying the URI, `{+pattern}` templates should allow reserved characters and pct-triplets. There's no built-in function for that in JS, so I've had to make my own.
- On expansion, for speed, we build just a `path` array, but we loose metadata on how the elements should be escaped on stringifying, so I've added additional property, `pathMetadata`
- In constructor, always initialise every field to make an object monomorphic.
