### PR TITLE
Added a strip function to the templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,5 @@ Several utility methods are supported:
 - `$$.default(template, defaultValue)` - if `template` is resolved, use it's value, otherwise use `defaultValue`.
 - `$$.merge(template1, template2)` - both templates should be evaluated to objects. The result is an object
    with merged properties, but without overriding.
+- `$$.strip(object, properties)` - removes field names listed in `properties` array from an `object`. `properties`
+   could also be a string, if a single field should be removed.

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -15,7 +15,8 @@ var globalMethods = {
         source = source || {};
 
         if (typeof destination !== 'object' || typeof source !== 'object') {
-            throw new Error('Illegal argument. Merge source and destination must be objects');
+            throw new Error('Illegal argument. ' +
+                'Merge source and destination must be objects');
         }
 
         var result = Object.assign({}, destination);
@@ -28,7 +29,8 @@ var globalMethods = {
     },
     strip: function(object, properties) {
         if (typeof object !== 'object') {
-            throw new Error('Illegal argument. Strip can only be applied to objects');
+            throw new Error('Illegal argument. ' +
+                'Strip can only be applied to objects');
         }
         object = Object.assign({}, object);
         if (typeof properties === 'string') {
@@ -38,7 +40,8 @@ var globalMethods = {
                 delete object[prop];
             });
         } else {
-            throw new Error('Illegal argument. Strip "properties" argument must be string or array');
+            throw new Error('Illegal argument. ' +
+                'Strip "properties" argument must be string or array');
         }
         return object;
     }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -15,7 +15,7 @@ var globalMethods = {
         source = source || {};
 
         if (typeof destination !== 'object' || typeof source !== 'object') {
-            throw new Error('Illegal spec. Merge source and destination must be objects');
+            throw new Error('Illegal argument. Merge source and destination must be objects');
         }
 
         var result = Object.assign({}, destination);
@@ -28,7 +28,7 @@ var globalMethods = {
     },
     strip: function(object, properties) {
         if (typeof object !== 'object') {
-            throw new Error('Illegal spec. Strip can only be applied to objects');
+            throw new Error('Illegal argument. Strip can only be applied to objects');
         }
         object = Object.assign({}, object);
         if (typeof properties === 'string') {
@@ -38,7 +38,7 @@ var globalMethods = {
                 delete object[prop];
             });
         } else {
-            throw new Error('Invalid spec. Strip "properties" argument must be string or array');
+            throw new Error('Illegal argument. Strip "properties" argument must be string or array');
         }
         return object;
     }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -25,6 +25,22 @@ var globalMethods = {
             }
         });
         return result;
+    },
+    strip: function(object, properties) {
+        if (typeof object !== 'object') {
+            throw new Error('Illegal spec. Strip can only be applied to objects');
+        }
+        object = Object.assign({}, object);
+        if (typeof properties === 'string') {
+            delete object[properties];
+        } else if (Array.isArray(properties)) {
+            properties.forEach(function(prop) {
+                delete object[prop];
+            });
+        } else {
+            throw new Error('Invalid spec. Strip "properties" argument must be string or array');
+        }
+        return object;
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -315,4 +315,31 @@ describe('Request template', function() {
         var result = template.expand({ request: request });
         assert.deepEqual(result, 'get');
     });
+
+    it('should strip the object', function() {
+        var template = new Template({
+            method: 'get',
+            uri: 'test.com',
+            headers: '{$$.strip($.request.headers, "removed_header")}',
+            body: '{$$.strip($.request.body, ["removed_field1", "removed_field2"])}'
+        });
+        var result = template.expand({
+            request: {
+                headers: {
+                    not_removed_header: 'value',
+                    removed_header: 'value'
+                },
+                body: {
+                    not_removed_field: 'value',
+                    removed_field1: 'value',
+                    removed_field2: 'value'
+                }
+            }
+        });
+        assert.deepEqual(result.headers.not_removed_header, 'value');
+        assert.deepEqual(result.headers.removed_header, undefined);
+        assert.deepEqual(result.body.not_removed_field, 'value');
+        assert.deepEqual(result.body.removed_field1, undefined);
+        assert.deepEqual(result.body.removed_field2, undefined);
+    });
 });


### PR DESCRIPTION
Added a `strip` function support for templates to remove some properties from an object.
Primary use-case - remove `content-length` header from backend `complete` response headers.
