### PR TITLE
URI templating fixes and general optimizations

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -44,10 +44,27 @@ var globalMethods = {
                 'Strip "properties" argument must be string or array');
         }
         return object;
+    },
+    _optionalPath: function(element) {
+        if (element !== undefined) {
+            return '/' + encodeURIComponent(element);
+        } else {
+            // Terminate the path
+            throw '';
+        }
+    },
+    _encodeURIComponent: function(s) {
+        s = s || '';
+        if (/[^\w_-]/.test(s)) {
+            return encodeURIComponent(s);
+        } else {
+            return s;
+        }
     }
 };
 
-function splitAndPrepareTAsseblyTemplate(templateSpec, part) {
+function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
+    options = options || {};
     var result = [];
     var templateNest = 0;
     var startIndex = 0;
@@ -64,10 +81,23 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, part) {
         } else if (templateSpec[index] === '}') {
             if (templateNest === 1) { // The current template is finished
                 currentTemplate = templateSpec.substring(startIndex, index);
+                if (options.isURI) {
+                    if (/^\+/.test(currentTemplate)) {
+                        // literal substitution, just strip the prefix.
+                        currentTemplate = currentTemplate.substring(1);
+                    } else if (/^\//.test(currentTemplate)) {
+                        currentTemplate = '$$._optionalPath(' + currentTemplate.substring(1) + ')';
+                    } else {
+                        currentTemplate = '$$._encodeURIComponent(' + currentTemplate + ')';
+                    }
+                }
+
                 var compiledExpression = expressionCompiler.parse(currentTemplate);
                 // FIXME: Rewrite path prefixes in expressionCompiler!
-                compiledExpression = compiledExpression.replace(/([,(\[:])m\./g,
-                            '$1rm.' + part + '.');
+                if (options.part) {
+                    compiledExpression = compiledExpression.replace(/([,(\[:])m\./g,
+                                '$1rm.' + options.part + '.');
+                }
                 result.push(['raw', compiledExpression]);
                 startIndex = index + 1;
             } // Or and object literal finished
@@ -87,7 +117,7 @@ function errorHandler(e) {
     return undefined;
 }
 
-function compileTAssembly(template, reqPart) {
+function compileTAssembly(template, reqPart, globals) {
     var res;
     var callback = function(bit) {
         if (res === undefined) {
@@ -101,7 +131,7 @@ function compileTAssembly(template, reqPart) {
         nestedTemplate: true,
         errorHandler: errorHandler,
         cb: callback,
-        globals: globalMethods,
+        globals: globals || globalMethods,
     };
     var resolveTemplate = TAssembly.compile(template, options);
 
@@ -109,9 +139,10 @@ function compileTAssembly(template, reqPart) {
         var childContext = {
             rc: context.rc,
             rm: context.rm,
-            m: context.rm.request[reqPart],
-            cb: options.cb,
+            g: options.globals,
             options: context.options || options,
+            cb: options.cb,
+            m: context.rm.request[reqPart],
         };
 
         resolveTemplate(childContext);
@@ -126,36 +157,21 @@ function compileTAssembly(template, reqPart) {
  * @param {object} spec a root request spec object
  * @returns {Function} a template resolver which should be applied to resolve URI
  */
-function createURIResolver(spec) {
-    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\$?\..+}/.test(spec.uri)) {
-        var tassemblyTemplate = splitAndPrepareTAsseblyTemplate(spec.uri);
-        var resolver = compileTAssembly(tassemblyTemplate, 'params');
+
+function createURIResolver(uri, globals) {
+    // Check if this is a simple path template
+    if (/^\/(?:[^{]*\{[\/\+]?[a-zA-Z_-]+\}[^{]*)*$/.test(uri)) {
+        var pathTemplate = new URI(uri, {}, true);
         return function(context) {
-            var value = resolver(context);
-            if (value.constructor !== URI) {
-                value = new URI(value, {}, false);
-            }
-            return value;
+            return pathTemplate.expand(context.rm.request.params);
         };
-    } else if (/^(?:https?:\/\/)?\{[^\/]+}\//.test(spec.uri)) {
-        // The host is templated - replace it with TAssembly and use URI.expand for path templates
-        var hostTemplate = /^((?:https?:\/\/)?\{[^\/]+}\/)/.exec(spec.uri)[1];
-        var hostTassembly = splitAndPrepareTAsseblyTemplate(hostTemplate);
-        var hostResolver = compileTAssembly(hostTassembly, 'params');
-        var path = spec.uri.substr(hostTemplate.length);
-        var pathTemplate = new URI('/' + path, {}, true);
-        return function(context) {
-            var newHost = hostResolver(context);
-            // FIXME: Support references to other parts of the request.
-            // params['$'] = context.rm;
-            var newUri = pathTemplate.expand(context.rm.request.params);
-            newUri.urlObj = url.parse(newHost + path);
-            return newUri;
-        };
+    } else if (/\{/.test(uri)) {
+        var tassemblyTemplate = splitAndPrepareTAsseblyTemplate(uri, { isURI: true });
+        // console.log('tass', spec.uri, tassemblyTemplate);
+        return compileTAssembly(tassemblyTemplate, 'params', globals);
     } else {
-        var uriTemplate = new URI(spec.uri, {}, true);
         return function(context) {
-            return uriTemplate.expand(context.rm.request.params);
+            return uri;
         };
     }
 }
@@ -196,11 +212,11 @@ function replaceComplexTemplates(part, subSpec, globals) {
                     return '$.' + subSpec;
                 }
             } else {
-                var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, part);
+                var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, { part: part });
                 if (tAssemblyTemplates.length > 1) {
                     // This is a string with partial templates
                     // Compile a function
-                    var resolver = compileTAssembly(tAssemblyTemplates, part);
+                    var resolver = compileTAssembly(tAssemblyTemplates, part, globals);
                     // Replace the complex template with a function call
                     var fnName = 'fn_' + globals._i++;
                     globals[fnName] = resolver;
@@ -238,10 +254,12 @@ function _cloneSpec(spec) {
  *              containing all request parts templated in the form of {a.b.c}.
  *              Only fields in the spec would be included in the resulting request,
  *              fields that couldn't be resolved from original request would be ignored.
+ * @param {object} globalsInit, an object to merge into the global namespace
+ *              available in the template.
  */
-function Template(spec) {
+function Template(spec, globalsInit) {
     var self = this;
-    var globals = Object.assign({}, globalMethods);
+    var globals = Object.assign({}, globalMethods, globalsInit);
     spec = _cloneSpec(spec);
     globals._i = 0;
 
@@ -250,8 +268,8 @@ function Template(spec) {
     } else {
         Object.keys(spec).forEach(function(part) {
             if (part === 'uri') {
-                globals.uri = createURIResolver(spec);
-                spec.uri = '$$.uri($context)';
+                globals._uri = createURIResolver(spec.uri, globals);
+                spec.uri = '$$._uri($context)';
             } else if (part === 'method') {
                 spec.method = "'" + (spec.method || 'get') + "'";
             } else {
@@ -280,9 +298,11 @@ function Template(spec) {
     };
     var c = {
         rc: null,
+        rm: null,
         g: globals,
         options: options,
         cb: callback,
+        m: null,
     };
     c.rc = c;
     self.expand = function(m) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -92,7 +92,7 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
                     }
                 }
 
-                var compiledExpression = expressionCompiler.parse(currentTemplate);
+                var compiledExpression = expressionCompiler.parse(currentTemplate.trim());
                 // FIXME: Rewrite path prefixes in expressionCompiler!
                 if (options.part) {
                     compiledExpression = compiledExpression.replace(/([,(\[:])m\./g,

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var url = require('url');
 var utils = require('./utils');
 /**
  * Represents a URI object which can optionally contain and
@@ -16,26 +15,24 @@ var utils = require('./utils');
 function URI(uri, params, asPattern) {
     // Initialise all fields to make an object monomorphic
     this.params = params || {};
-    this.urlObj = null;
-    this.path = [];
+    this.protoHost = null;
+    this.path = null;
     this._pathMetadata = {};
 
-    if (uri && uri.constructor === URI) {
-        this.urlObj = uri.urlObj;
+    if (typeof uri === 'string') {
+        var protoHostMatch = /^[^\/]+:(?:\/\/)?[^\/]+/.exec(uri);
+        if (protoHostMatch) {
+            this.protoHost = protoHostMatch[0];
+            uri = uri.substring(this.protoHost.length);
+        }
+        this.path = utils.parsePath(uri, asPattern);
+    } else if (Array.isArray(uri)) {
+        this.path = uri;
+    } else if (uri && uri.constructor === URI) {
+        this.protoHost = uri.protoHost;
         // this.path is considered immutable, so can be shared with other URI
         // instances
         this.path = uri.path;
-    } else if (uri && (uri.constructor === String || Array.isArray(uri))) {
-        if (uri.constructor === String) {
-            if (/^[^\/]+:/.test(uri)) {
-                this.urlObj = url.parse(uri);
-                // Work around encoding difference for {} between node 0.10 &
-                // 0.12 / iojs. 0.10 leaves those chars as they are in .path,
-                // newer node versions percent-encode them.
-                uri = uri.substr(this.urlObj.resolve('/').length - 1);
-            }
-        }
-        this.path = utils.parsePath(uri, asPattern);
     } else if (uri !== '') {
         throw new Error('Invalid path passed into URI constructor: ' + uri);
     }
@@ -57,8 +54,7 @@ URI.prototype.toString = function(options) {
         options = { format: options };
     }
     var params = options.params || this.params;
-    var uriStr = this.urlObj && this.urlObj.resolve('/').replace(/\/$/, '')
-    || '';
+    var uriStr = this.protoHost || '';
     for (var i = 0; i < this.path.length; i++) {
         var segment = this.path[i];
         if (segment && segment.constructor === Object) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,16 @@
 "use strict";
 
+var url = require('url');
+
 var utils = {};
 
 function robustDecodeURIComponent(uri) {
     if (!/%/.test(uri)) {
         return uri;
-    } else {
+    }
+    try {
+        return decodeURIComponent(uri);
+    } catch (e) {
         return uri.replace(/(%[0-9a-fA-F][0-9a-fA-F])+/g, function(m) {
             try {
                 return decodeURIComponent(m);
@@ -61,15 +66,18 @@ utils.parsePath = function(path, isPattern) {
     if (Array.isArray(path)) {
         return path;
     } else if (!isPattern) {
-        var bits = path.replace(/^\//, '').split(/\//);
-        if (!/%/.test(path)) {
-            // fast path
-            return bits;
-        } else {
-            return bits.map(function(bit) {
-                return robustDecodeURIComponent(bit);
-            });
+        if (path.charCodeAt(0) === 47 /* "/" */) {
+            path = path.substring(1);
         }
+        var bits = path.split('/');
+        if (/%/.test(path)) {
+            for (var i = 0; i < bits.length; i++) {
+                if (/%/.test(bits[i])) {
+                    bits[i] = robustDecodeURIComponent(bits[i]);
+                }
+            }
+        }
+        return bits;
     } else {
         return parsePattern(path);
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha",
     "coverage": "istanbul cover _mocha -- -R spec",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "bench": "node test/bench.js"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,7 @@
   },
   "dependencies": {
     "bluebird": "2.8.2",
-    "core-js": "^1.2.2",
+    "core-js": "^1.2.6",
     "js-yaml": "^3.4.2",
     "tassembly": "^0.2.0",
     "template-expression-compiler": "^0.1.0"

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var URI = require('../index').URI;
+var Template = require('../index').Template;
+
+function simple() {
+    var requestTemplate = new Template({
+        uri: '/{domain}/a/{b}/{c}{/d}'
+    });
+
+    var n = 1000000;
+    var start = Date.now();
+    for (var i = 0; i < n; i++) {
+        var uri = new URI(requestTemplate.expand({
+            request: {
+                params: {
+                    domain: 'en.wikipedia.org',
+                    b: 'foobar',
+                    c: 'baaz',
+                    d: 'ddeeee'
+                }
+            }
+        }).uri);
+    }
+    console.log((Date.now() - start) / n, 'ms per iteration');
+}
+simple();
+

--- a/test/features/uri.js
+++ b/test/features/uri.js
@@ -118,7 +118,6 @@ describe('URI', function() {
 
     it('handle protocols', function() {
         var uri = new URI('https://test.com/v1/page/title');
-        deepEqual(uri.urlObj.protocol, 'https:');
         deepEqual(uri.path[0], 'v1');
         deepEqual(uri.toString(), 'https://test.com/v1/page/title');
     });


### PR DESCRIPTION
- Fix a serious bug that caused more complex templated URI segments to not be
  escaped. Constructs like `{/$default(...)}` weren't even compiling.
- Remove the special-case handling for templated host names. This is now
  handled by regular tassembly, with support for both escaping and verbatim
  substitution via `{+somevar}`. This lets us template any part of URLs.
- Correct the handling of arrays passed to URI template parameters. The
  default behavior according to the spec is to join with commas, not slashes.
- Add a 'bench' command for template expansion.
- Remove the nested URL instance & only keep a simple protoHost prefix. We
  don't really need all those sub-properties right now, and parsing this does
  cost a little bit of CPU time.
