### PR TITLE
Flatten visitAync calls and release v0.2.7

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -118,20 +118,19 @@ Node.prototype.visitAsync = function(fn, path) {
     path = path || [];
     var self = this;
     // First value, then each of the children (one by one)
-    return fn(self.value, path)
-    .then(function() {
-        return P.resolve(Object.keys(self._children))
-        .each(function(childKey) {
-            var segment = childKey.replace(/^\//, '');
+    var visitP = fn(self.value, path);
+    if (Object.keys(self._children).length > 0) {
+        Object.keys(self._children).forEach(function(childKey) {
+            var segment = childKey[0] === '/' ? childKey.substr(1) : childKey;
             var child = self._children[childKey];
-            if (child === self) {
-                // Don't enter an infinite loop on **
-                return;
-            } else {
-                return child.visitAsync(fn, path.concat([segment]));
+            if (child !== self) {
+                visitP = visitP.then(function() {
+                    return child.visitAsync(fn, path.concat([segment]));
+                });
             }
         });
-    });
+    }
+    return visitP;
 };
 
 // Work around recursive structure in ** terminal nodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Before, we were blidly calling P.each() for a node's children even if
there were no children to visit. Moreover, using P.each seems to create
a Promise hierarchy flattened into a long chain, which apparently node
0.10's version of libuv doesn't like (any more).

This commit fixes that by first checking if there's even a need to
decend into a node's children. If there's not, the chain is broken.
Otherwise, each child's call is placed in a separate .then() block.
