### PR TITLE
Arrow expression syntax

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -263,7 +263,11 @@ function replaceComplexTemplates(part, subSpec, globals) {
             return replaceComplexTemplates(part, elem, globals);
         });
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
-        if (/\{.*\}/.test(subSpec)) {
+        if (/^\s*=>/.test(subSpec)) {
+            // Arrow expression
+            subSpec = subSpec.replace(/^\s*=>/, '');
+            subSpec = compileExpression(subSpec, part);
+        } else if (/\{.*\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
             if (/^\{[^\}]+\}$/.test(subSpec)) {
                 // Single expression: Remove braces

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -468,4 +468,36 @@ describe('Request template', function() {
             }
         });
     });
+
+    it('should support expressions using arrow syntax', function() {
+        var template = new Template({
+            uri: '{{options.host}}/{foo}/',
+            headers: {
+                bar: '=> bar',
+                baz: '=> baz',
+            }
+        });
+        var request = {
+            headers: {
+                bar: 'a/bar',
+                baz: 'a/baz',
+            },
+            uri: 'test.com',
+            body: {
+                field: 'method'
+            },
+            params: {
+                foo: 'a/foo',
+            }
+        };
+        var result = template.expand({ request: request, options: { host: '/a/host' } });
+        assert.deepEqual(result, {
+            uri: '/a/host/a%2Ffoo/',
+            headers: {
+                bar: 'a/bar',
+                // FIXME: This will change in the future!
+                baz: 'a/baz',
+            }
+        });
+    });
 });


### PR DESCRIPTION
This patch proposes a lighter weight syntax for reference expressions, which
are extremely common in request templates:

``` yaml
body:
  foo: => some.expression
  bar: => frobnicate(request.headers)
```

See https://github.com/wikimedia/swagger-router/pull/30#issuecomment-158231870
for the original discussion that spawned this.
