### PR TITLE
Cleanup & minor fixes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,7 +11,7 @@
     "curly": true,
     "eqeqeq": true,
     "immed": true,
-    "latedef": true,
+    "latedef": "nofunc",
     "newcap": true,
     "noarg": true,
     "noempty": true,

--- a/lib/node.js
+++ b/lib/node.js
@@ -149,7 +149,9 @@ function printableValue(value) {
                 newMethods[method] = '<' + val[method].name + '>';
             });
             res.methods = newMethods;
-        } else {
+        // Omit the specRoot, as it tends to be huge & contains reference
+        // circles.
+        } else if (key !== 'specRoot') {
             res[key] = val;
         }
     });
@@ -171,5 +173,6 @@ Node.prototype.toJSON = function() {
         };
     }
 };
+
 
 module.exports = Node;

--- a/lib/node.js
+++ b/lib/node.js
@@ -109,6 +109,7 @@ Node.prototype.keys = function() {
 Node.prototype.clone = function() {
     var c = new Node();
     c._children = this._children;
+    c._paramName = this._paramName;
     return c;
 };
 
@@ -118,19 +119,20 @@ Node.prototype.visitAsync = function(fn, path) {
     path = path || [];
     var self = this;
     // First value, then each of the children (one by one)
-    var visitP = fn(self.value, path);
-    if (Object.keys(self._children).length > 0) {
-        Object.keys(self._children).forEach(function(childKey) {
-            var segment = childKey[0] === '/' ? childKey.substr(1) : childKey;
+    return fn(self.value, path)
+    .then(function() {
+        return P.resolve(Object.keys(self._children))
+        .each(function(childKey) {
+            var segment = childKey.replace(/^\//, '');
             var child = self._children[childKey];
-            if (child !== self) {
-                visitP = visitP.then(function() {
-                    return child.visitAsync(fn, path.concat([segment]));
-                });
+            if (child === self) {
+                // Don't enter an infinite loop on **
+                return;
+            } else {
+                return child.visitAsync(fn, path.concat([segment]));
             }
         });
-    }
-    return visitP;
+    });
 };
 
 // Work around recursive structure in ** terminal nodes

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -10,6 +10,10 @@ var compilerOptions = {
     ctxMap: {
         $: 'rm',
         $$: 'rc.g',
+        globals: 'rm',
+        // `global` is deprecated, as `globals` (plural) is more consistent
+        // with `options` & the code.
+        // TODO: Remove!
         global: 'rm',
     },
     dottedPathPrefix: 'rm',
@@ -80,6 +84,13 @@ var globalMethods = {
         // TODO: Add support for
         // - multiple predicates (via arguments)
         // - function predicates
+    },
+
+    requestTemplate: function(spec, options) {
+        var tpl = new Template(spec, options);
+        return function(model) {
+            return tpl.expand(model);
+        };
     },
 
     // Private helpers
@@ -189,7 +200,8 @@ function compileTAssembly(template, reqPart, globals) {
             g: options.globals,
             options: context.options || options,
             cb: options.cb,
-            m: context.rm.request[reqPart],
+            m: (!reqPart && context.rm)
+                || (context.rm.request && context.rm.request[reqPart]),
         };
 
         resolveTemplate(childContext);

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -174,7 +174,13 @@ function compileTAssembly(template, reqPart, globals) {
         cb: stringCb,
         globals: globals || globalMethods,
     };
-    var resolveTemplate = TAssembly.compile(template, options);
+    try {
+        var resolveTemplate = TAssembly.compile(template, options);
+    } catch (e) {
+        e.template = template;
+        e.part = reqPart;
+        throw e;
+    }
 
     return function(context) {
         var childContext = {
@@ -326,12 +332,21 @@ function Template(origSpec, globalsInit) {
             res = bit;
         }
     };
-    var resolver = TAssembly.compile([['raw', completeTAssemblyTemplate]], {
-        nestedTemplate: true,
-        globals: globals,
-        cb: objectCb,
-        errorHandler: null,
-    });
+
+    var resolver;
+    try {
+        resolver = TAssembly.compile([['raw', completeTAssemblyTemplate]], {
+            nestedTemplate: true,
+            globals: globals,
+            cb: objectCb,
+            errorHandler: null,
+        });
+    } catch (e) {
+        e.spec = origSpec;
+        e.tassembly = completeTAssemblyTemplate;
+        throw e;
+    }
+
     var c = {
         rc: null,
         rm: null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Copy the _paramName property when cloning a node.
- Go back to P.each for resource processing.
- Report the input spec & tassembly source when encountering expansion errors.
  This is helpful during development and debugging.

This reverts commit 4d7ba521ca1548b32bc93bcbd402ab60d7c7d62a.
