### PR TITLE
Fixed a problem when falsy values were not substituted on expansion

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -174,7 +174,7 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
 function compileTAssembly(template, reqPart, globals) {
     var res = '';
     var stringCb = function(bit) {
-        if (bit) {
+        if (bit !== undefined && bit !== null) {
             res += '' + bit;
         }
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -163,7 +163,6 @@ describe('Request template', function() {
                 }
             }
         }).uri.toString();
-        console.log(resultNoOptional);
         assert.deepEqual(resultNoOptional, '/en.wikipedia.org/b/path');
         var resultWithOptional = new Template(requestTemplate).expand({
             request: {
@@ -466,6 +465,22 @@ describe('Request template', function() {
                 // FIXME: This will change in the future!
                 baz: 'a/baz',
             }
+        });
+    });
+
+    it('should correctly resolve 0 value', function() {
+        var template = new Template({
+            headers: 'test_{test_header}'
+        });
+        var result = template.expand({
+            request: {
+                headers: {
+                    test_header: 0
+                }
+            }
+        });
+        assert.deepEqual(result, {
+            headers: 'test_0'
         });
     });
 });


### PR DESCRIPTION
The problem is obvious: if the variable value was falsy, it was not added to the result of the expansion, so we couldn't substitute false or a zero.
