### PR TITLE
Correctly substitute falsy in URI special-case

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -102,7 +102,7 @@ var globalMethods = {
         }
     },
     _encodeURIComponent: function(s) {
-        s = s || '';
+        s = (s === undefined || s === null) ? '' : s;
         if (/[^\w_-]/.test(s)) {
             return encodeURIComponent(s);
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -470,16 +470,21 @@ describe('Request template', function() {
 
     it('should correctly resolve 0 value', function() {
         var template = new Template({
+            uri: 'http://test.com/{rev}',
             headers: 'test_{test_header}'
         });
         var result = template.expand({
             request: {
+                params: {
+                    rev: 0
+                },
                 headers: {
                     test_header: 0
                 }
             }
         });
         assert.deepEqual(result, {
+            uri: 'http://test.com/0',
             headers: 'test_0'
         });
     });


### PR DESCRIPTION
The `_encodeURIComponent` function, called on falsy was returning an incorrect result.
