### PR TITLE
Support newlines in expressions & release v0.3.4

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -22,6 +22,8 @@ var compilerOptions = {
 };
 
 function compileExpression(expression, part) {
+    // Convert the expression to a single line & remove whitespace.
+    expression = expression.replace(/\n/g, ' ').trim();
     compilerOptions.modelPrefix = (part && 'rm.request.' + part) || 'm';
     return expressionCompiler.parse(expression, compilerOptions);
 }
@@ -154,8 +156,7 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
                     inDoubleBrace = false;
                 }
 
-                var compiledExpression = compileExpression(currentTemplate.trim(),
-                    options.part);
+                var compiledExpression = compileExpression(currentTemplate, options.part);
                 result.push(['raw', compiledExpression]);
                 startIndex = index + 1;
             } // Or and object literal finished
@@ -263,7 +264,7 @@ function replaceComplexTemplates(part, subSpec, globals) {
             return replaceComplexTemplates(part, elem, globals);
         });
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
-        if (/\{.*\}/.test(subSpec)) {
+        if (/\{[^\}]+\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
             if (/^\{[^\}]+\}$/.test(subSpec)) {
                 // Single expression: Remove braces

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -468,6 +468,36 @@ describe('Request template', function() {
         });
     });
 
+    it('should support newlines in expressions', function() {
+        var template = new Template({
+            uri: '{{options.host}}/{foo}/',
+            headers: '{{filter(\nrequest.headers, \n["bar","baz"])\n }}',
+        });
+        var request = {
+            headers: {
+                bar: 'a/bar',
+                baz: 'a/baz',
+                boo: 'a/boo',
+            },
+            uri: 'test.com',
+            body: {
+                field: 'method'
+            },
+            params: {
+                foo: 'a/foo',
+            }
+        };
+        var result = template.expand({ request: request, options: { host: '/a/host' } });
+        assert.deepEqual(result, {
+            uri: '/a/host/a%2Ffoo/',
+            headers: {
+                bar: 'a/bar',
+                // FIXME: This will change in the future!
+                baz: 'a/baz',
+            }
+        });
+    });
+
     it('should correctly resolve 0 value', function() {
         var template = new Template({
             uri: 'http://test.com/{rev}',


### PR DESCRIPTION
Template expressions are currently limited to a single line, which forces us
to squeeze complex expressions into long lines. These expressions would be a
lot more readable if we could break them up into multiple lines, and indent
them to reflect the logical structure.

This patch adds simple multi-line expression support by simply replacing
newlines with a space.
