### PR TITLE
Clean up single vs. double brace handling

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -140,7 +140,7 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
 
                 // TODO: Enable single brace structures outside of URI once
                 // the specs are migrated to double brace.
-                if (!inDoubleBrace && options.isURI) {
+                if (!inDoubleBrace) {
                     if (/^\+/.test(currentTemplate)) {
                         // literal substitution, just strip the prefix.
                         currentTemplate = currentTemplate.substring(1);
@@ -266,9 +266,9 @@ function replaceComplexTemplates(part, subSpec, globals) {
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
         if (/\{[^\}]+\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
-            if (/^\{[^\}]+\}$/.test(subSpec)) {
+            if (/^\{\{[^\{\}]+\}\}$/.test(subSpec)) {
                 // Single expression: Remove braces
-                subSpec = subSpec.substring(1, subSpec.length - 1);
+                subSpec = subSpec.substring(2, subSpec.length - 2);
                 subSpec = compileExpression(subSpec, part);
             } else {
                 var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, { part: part });

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -22,6 +22,8 @@ var compilerOptions = {
 };
 
 function compileExpression(expression, part) {
+    // Convert the expression to a single line & remove whitespace.
+    expression = expression.replace(/\n/g, ' ').trim();
     compilerOptions.modelPrefix = (part && 'rm.request.' + part) || 'm';
     return expressionCompiler.parse(expression, compilerOptions);
 }
@@ -154,8 +156,7 @@ function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
                     inDoubleBrace = false;
                 }
 
-                var compiledExpression = compileExpression(currentTemplate.trim(),
-                    options.part);
+                var compiledExpression = compileExpression(currentTemplate, options.part);
                 result.push(['raw', compiledExpression]);
                 startIndex = index + 1;
             } // Or and object literal finished
@@ -263,7 +264,7 @@ function replaceComplexTemplates(part, subSpec, globals) {
             return replaceComplexTemplates(part, elem, globals);
         });
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
-        if (/\{.*\}/.test(subSpec)) {
+        if (/\{[^\}]+\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
             if (/^\{[^\}]+\}$/.test(subSpec)) {
                 // Single expression: Remove braces

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -237,7 +237,7 @@ function createURIResolver(uri, globals) {
             return pathTemplate.expand(context.rm.request.params);
         };
     } else if (/\{/.test(uri)) {
-        var tassemblyTemplate = splitAndPrepareTAssemblyTemplate(uri, { isURI: true });
+        var tassemblyTemplate = splitAndPrepareTAssemblyTemplate(uri);
         // console.log('tass', spec.uri, tassemblyTemplate);
         return compileTAssembly(tassemblyTemplate, 'params', globals);
     } else {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -113,7 +113,7 @@ var globalMethods = {
     }
 };
 
-function splitAndPrepareTAsseblyTemplate(templateSpec, options) {
+function splitAndPrepareTAssemblyTemplate(templateSpec, options) {
     options = options || {};
     var result = [];
     var templateNest = 0;
@@ -237,7 +237,7 @@ function createURIResolver(uri, globals) {
             return pathTemplate.expand(context.rm.request.params);
         };
     } else if (/\{/.test(uri)) {
-        var tassemblyTemplate = splitAndPrepareTAsseblyTemplate(uri, { isURI: true });
+        var tassemblyTemplate = splitAndPrepareTAssemblyTemplate(uri, { isURI: true });
         // console.log('tass', spec.uri, tassemblyTemplate);
         return compileTAssembly(tassemblyTemplate, 'params', globals);
     } else {
@@ -266,26 +266,20 @@ function replaceComplexTemplates(part, subSpec, globals) {
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
         if (/\{[^\}]+\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
-            if (/^\{\{[^\{\}]+\}\}$/.test(subSpec)) {
-                // Single expression: Remove braces
-                subSpec = subSpec.substring(2, subSpec.length - 2);
-                subSpec = compileExpression(subSpec, part);
+            var tAssemblyTemplates = splitAndPrepareTAssemblyTemplate(subSpec, { part: part });
+            if (tAssemblyTemplates.length === 1
+                    && tAssemblyTemplates[0].length === 2
+                    && tAssemblyTemplates[0][0] === 'raw') {
+                // Simple expression. Return verbatim.
+                return tAssemblyTemplates[0][1];
             } else {
-                var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, { part: part });
-                if (tAssemblyTemplates.length === 1
-                        && tAssemblyTemplates[0].length === 2
-                        && tAssemblyTemplates[0][0] === 'raw') {
-                    // Simple expression. Return verbatim.
-                    return tAssemblyTemplates[0][1];
-                } else {
-                    // This is a string with partial templates
-                    // Compile a function
-                    var resolver = compileTAssembly(tAssemblyTemplates, part, globals);
-                    // Replace the complex template with a function call
-                    var fnName = 'fn_' + globals._i++;
-                    globals[fnName] = resolver;
-                    return 'rc.g.' + fnName + '(c)';
-                }
+                // This is a string with partial templates
+                // Compile a function
+                var resolver = compileTAssembly(tAssemblyTemplates, part, globals);
+                // Replace the complex template with a function call
+                var fnName = 'fn_' + globals._i++;
+                globals[fnName] = resolver;
+                return 'rc.g.' + fnName + '(c)';
             }
         } else {
             // If it's not templated - wrap it into braces to let tassembly add it

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -138,8 +138,6 @@ function splitAndPrepareTAssemblyTemplate(templateSpec, options) {
 
                 currentTemplate = templateSpec.substring(startIndex, index);
 
-                // TODO: Enable single brace structures outside of URI once
-                // the specs are migrated to double brace.
                 if (!inDoubleBrace) {
                     if (/^\+/.test(currentTemplate)) {
                         // literal substitution, just strip the prefix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -468,6 +468,36 @@ describe('Request template', function() {
         });
     });
 
+    it('should support newlines in expressions', function() {
+        var template = new Template({
+            uri: '{{options.host}}/{foo}/',
+            headers: '{{filter(\nrequest.headers, \n["bar","baz"])\n }}',
+        });
+        var request = {
+            headers: {
+                bar: 'a/bar',
+                baz: 'a/baz',
+                boo: 'a/boo',
+            },
+            uri: 'test.com',
+            body: {
+                field: 'method'
+            },
+            params: {
+                foo: 'a/foo',
+            }
+        };
+        var result = template.expand({ request: request, options: { host: '/a/host' } });
+        assert.deepEqual(result, {
+            uri: '/a/host/a%2Ffoo/',
+            headers: {
+                bar: 'a/bar',
+                // FIXME: This will change in the future!
+                baz: 'a/baz',
+            }
+        });
+    });
+
     it('should correctly resolve 0 value', function() {
         var template = new Template({
             uri: 'http://test.com/{rev}',

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -13,28 +13,28 @@ describe('Request template', function() {
             uri: '/{domain}/test',
             method: 'post',
             headers: {
-                'name-with-dashes': '{name-with-dashes}',
-                'global-header': '{$.request.params.domain}',
+                'name-with-dashes': '{{name-with-dashes}}',
+                'global-header': '{{request.params.domain}}',
                 'added-string-header': 'added-string-header'
             },
             query: {
-                'simple': '{simple}',
+                'simple': '{{simple}}',
                 'added': 'addedValue',
-                'global': '{$.request.headers.name-with-dashes}'
+                'global': '{{request.headers.name-with-dashes}}'
             },
             body: {
-                'object': '{object}',
-                'global': '{$.request.params.domain}',
+                'object': '{{object}}',
+                'global': '{{request.params.domain}}',
                 'added': 'addedValue',
                 'nested': {
                     'one': {
                         'two': {
-                            'tree': '{request.body.a.b.c}'
+                            'tree': '{{request.body.a.b.c}}'
                         }
                     }
                 },
-                'field_name_with_underscore': '{field_name_with_underscore}',
-                'additional_context_field': '{$.additional_context.field}',
+                'field_name_with_underscore': '{{field_name_with_underscore}}',
+                'additional_context_field': '{{additional_context.field}}',
                 'string_templated': 'test {field_name_with_underscore}'
             }
         };
@@ -63,7 +63,7 @@ describe('Request template', function() {
                         'c': 'nestedValue'
                     }
                 },
-                'field_name_with_underscore': 'field_value_with_underscore'
+                'field_name_with_underscore': 'field_value_with_underscore/'
             }
         };
         var expectedTemplatedRequest = {
@@ -92,9 +92,11 @@ describe('Request template', function() {
                         }
                     }
                 },
-                'field_name_with_underscore': 'field_value_with_underscore',
+                'field_name_with_underscore': 'field_value_with_underscore/',
                 additional_context_field: 'additional_test_value',
-                'string_templated': 'test field_value_with_underscore'
+                // Note how the slash is encoded, as the template is using
+                // single braces.
+                'string_templated': 'test field_value_with_underscore%2F'
             }
         };
         var result = new Template(requestTemplate).expand({
@@ -211,7 +213,7 @@ describe('Request template', function() {
 
     it('absolute templates in URI', function() {
         var template = new Template({
-            uri: '/path/{$.request.headers.host}/{$.request.body}'
+            uri: '/path/{request.headers.host}/{request.body}'
         });
         var request = {
             method: 'post',
@@ -225,11 +227,11 @@ describe('Request template', function() {
 
     it('supports default values in req templates', function() {
         var template = new Template({
-            uri: '/path/{$$.default($.request.body.test, "foo/bar")}',
+            uri: '/path/{default(request.body.test, "foo/bar")}',
             body: {
-                complete: '{$$.default($.request.body.test, "default")}',
-                partial: '/test/{$$.default($.request.body.test, "default")}',
-                withObject: '{$$.default($.request.body.test, {temp: "default"})}'
+                complete: '{{default(request.body.test, "default")}}',
+                partial: '/test/{{default(request.body.test, "default")}}',
+                withObject: '{{default(request.body.test, {temp: "default"})}}'
             }
         });
         var evaluatedNoDefaults = template.expand({
@@ -259,7 +261,7 @@ describe('Request template', function() {
     it('should support merging objects in templates', function() {
         var template = new Template({
             body: {
-                merged: '{$$.merge($.request.body.first, second)}'
+                merged: '{{merge(request.body.first, second)}}'
             }
         });
         var evaluated = template.expand({
@@ -285,7 +287,7 @@ describe('Request template', function() {
     });
 
     it('should support string templates', function() {
-        var template = new Template('{$.request}');
+        var template = new Template('{{request}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -298,7 +300,7 @@ describe('Request template', function() {
     });
 
     it('should support short notation in string templates', function() {
-        var template = new Template('{request}');
+        var template = new Template('{{request}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -311,7 +313,7 @@ describe('Request template', function() {
     });
 
     it('should support short nested notation in string templates', function() {
-        var template = new Template('{request.method}');
+        var template = new Template('{{request.method}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -324,7 +326,7 @@ describe('Request template', function() {
     });
 
     it('should support short nested notation with brackets in string templates', function() {
-        var template = new Template('{request[$.request.body.field]}');
+        var template = new Template('{{request[request.body.field]}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -340,8 +342,8 @@ describe('Request template', function() {
         var template = new Template({
             method: 'get',
             uri: 'test.com',
-            headers: '{$$.strip($.request.headers, "removed_header")}',
-            body: '{$$.strip($.request.body, ["removed_field1", "removed_field2"])}'
+            headers: '{{strip(request.headers, "removed_header")}}',
+            body: '{{strip(request.body, ["removed_field1", "removed_field2"])}}'
         });
         var result = template.expand({
             request: {
@@ -368,7 +370,7 @@ describe('Request template', function() {
      */
 
     it('should support un-prefixed dotted paths & the global accessor', function() {
-        var template = new Template('{request[request.body.field]}');
+        var template = new Template('{{request[request.body.field]}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -381,7 +383,7 @@ describe('Request template', function() {
     });
 
     it('should support un-prefixed calls', function() {
-        var template = new Template('{default(request.foo, request[request.body.field])}');
+        var template = new Template('{{default(request.foo, request[request.body.field])}}');
         var request = {
             method: 'get',
             uri: 'test.com',
@@ -432,8 +434,7 @@ describe('Request template', function() {
             uri: '/a/host/a%2Ffoo/',
             headers: {
                 bar: 'a/bar',
-                // FIXME: This will change in the future!
-                baz: 'a/baz',
+                baz: 'a%2Fbaz',
             }
         });
     });

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -463,7 +463,6 @@ describe('Request template', function() {
             uri: '/a/host/a%2Ffoo/',
             headers: {
                 bar: 'a/bar',
-                // FIXME: This will change in the future!
                 baz: 'a/baz',
             }
         });
@@ -493,7 +492,6 @@ describe('Request template', function() {
             uri: '/a/host/a%2Ffoo/',
             headers: {
                 bar: 'a/bar',
-                // FIXME: This will change in the future!
                 baz: 'a/baz',
             }
         });


### PR DESCRIPTION
- Consistently escape single brace expressions according to the rules of URI
  templates. This lets us sanely support general path segment templating as
  needed for https://phabricator.wikimedia.org/T126571.
- Remove old-style $ prefixes from tests, but still support them.
