### PR TITLE
Ensure that URI is indeed templated

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -229,7 +229,7 @@ var simpleTemplate = new RegExp('^(?:\\/(?:[a-zA-Z_\\.-]+|'
  */
 
 function createURIResolver(uri, globals) {
-    if (simpleTemplate.test(uri)) {
+    if (simpleTemplate.test(uri) && uri.indexOf('{') >= 0) {
         var pathTemplate = new URI(uri, {}, true);
         return function(context) {
             return pathTemplate.expand(context.rm.request.params);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In case of a simple template we check whether the URI template is in the form of `/{domain}/bla/bla`, so that it only references properties from `context.request.params` and apply a simplified expansion for speed. However, if the URI is not template at all (no `{` symbol) - we don't need to apply any templating at all. 

cc @wikimedia/services 
