### PR TITLE
Add date formatting function

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -111,9 +111,10 @@ var globalMethods = {
             return !isNaN(d.getTime());
         }
 
+        format = format || 'rfc822';
+
         if (!isValidDate(date)) {
             var origDate = date;
-            format = format || 'rfc822';
 
             if (typeof date === 'string') {
                 // It's a string, but may be it's just a stringified timestamp.

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -105,27 +105,29 @@ var globalMethods = {
     date: function(date, format) {
 
         function isValidDate(d) {
-            if (Object.prototype.toString.call(d) !== "[object Date]") {
+            if (d.constructor !== Date) {
                 return false;
             }
             return !isNaN(d.getTime());
         }
 
-        var origDate = date;
-        format = format || 'rfc822';
-
-        if (typeof date === 'string') {
-            // It's a string, but may be it's just a stringified timestamp.
-            // Check if it actually is.
-            var tempNumDate = parseInt(date);
-            if (!Number.isNaN(tempNumDate)) {
-                date = tempNumDate;
-            }
-        }
-        date = new Date(date);
-
         if (!isValidDate(date)) {
-            throw new Error('Invalid date: ' + origDate);
+            var origDate = date;
+            format = format || 'rfc822';
+
+            if (typeof date === 'string') {
+                // It's a string, but may be it's just a stringified timestamp.
+                // Check if it actually is.
+                var tempNumDate = parseInt(date);
+                if (!Number.isNaN(tempNumDate)) {
+                    date = tempNumDate;
+                }
+            }
+            date = new Date(date);
+
+            if (!isValidDate(date)) {
+                throw new Error('Invalid date: ' + origDate);
+            }
         }
 
         switch (format) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -5,6 +5,7 @@ var URI = require('./uri');
 var url = require('url');
 var TAssembly = require('tassembly');
 var expressionCompiler = require('template-expression-compiler');
+var rfc822Date = require('rfc822-date');
 
 var compilerOptions = {
     ctxMap: {
@@ -93,6 +94,48 @@ var globalMethods = {
         return function(model) {
             return tpl.expand(model);
         };
+    },
+
+    /**
+     * Formats a date in a requested format
+     *
+     * @param date date to format
+     * @param [format] optional format, defaults to RFC 822 format
+     */
+    date: function(date, format) {
+
+        function isValidDate(d) {
+            if (Object.prototype.toString.call(d) !== "[object Date]") {
+                return false;
+            }
+            return !isNaN(d.getTime());
+        }
+
+        var origDate = date;
+        format = format || 'rfc822';
+
+        if (typeof date === 'string') {
+            // It's a string, but may be it's just a stringified timestamp.
+            // Check if it actually is.
+            var tempNumDate = parseInt(date);
+            if (!Number.isNaN(tempNumDate)) {
+                date = tempNumDate;
+            }
+        }
+        date = new Date(date);
+
+        if (!isValidDate(date)) {
+            throw new Error('Invalid date: ' + origDate);
+        }
+
+        switch (format) {
+            case 'rfc822':
+                return rfc822Date(date);
+            case 'iso':
+                return date.toISOString();
+            default:
+                throw new Error('Unsupported date format: ' + format);
+        }
     },
 
     // Private helpers

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -5,7 +5,7 @@ var URI = require('./uri');
 var url = require('url');
 var TAssembly = require('tassembly');
 var expressionCompiler = require('template-expression-compiler');
-var rfc822Date = require('rfc822-date');
+var utils = require('./utils');
 
 var compilerOptions = {
     ctxMap: {
@@ -133,7 +133,7 @@ var globalMethods = {
 
         switch (format) {
             case 'rfc822':
-                return rfc822Date(date);
+                return utils.toRFC822Date(date);
             case 'iso':
                 return date.toISOString();
             default:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,4 +110,25 @@ utils.encodeReserved = function(string) {
     }
 };
 
+utils.toRFC822Date = function(date) {
+    var months	= ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    var days	= ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+    function numpad(x, digits) {
+        var result = Math.floor(x).toString();
+        while (result.length < digits) {
+            result = '0' + result;
+        }
+        return result;
+    }
+    return days[date.getUTCDay()] + ", "
+        + numpad(date.getUTCDate(), 2) + " "
+        + months[date.getUTCMonth()] + " "
+        + date.getUTCFullYear() + " "
+        + numpad(date.getUTCHours(), 2) + ":"
+        + numpad(date.getUTCMinutes(), 2) + ":"
+        + numpad(date.getUTCSeconds(), 2) + " +0000";
+};
+
 module.exports = utils;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "core-js": "^2.0.3",
     "js-yaml": "^3.5.2",
     "tassembly": "^0.2.3",
-    "template-expression-compiler": "^0.1.8",
-    "rfc822-date": "^0.0.3"
+    "template-expression-compiler": "^0.1.8"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,8 @@
     "core-js": "^2.0.3",
     "js-yaml": "^3.5.2",
     "tassembly": "^0.2.3",
-    "template-expression-compiler": "^0.1.8"
+    "template-expression-compiler": "^0.1.8",
+    "rfc822-date": "^0.0.3"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -565,7 +565,7 @@ describe('Request template', function() {
         assert.deepEqual(result, {
             body: {
                 date_iso: '1970-01-01T00:00:01.234Z',
-                date_rfc822: require('rfc822-date')(new Date(1234))
+                date_rfc822: 'Thu, 01 Jan 1970 00:00:01 +0000'
             }
         });
     });

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -547,4 +547,26 @@ describe('Request template', function() {
             headers: 'test_0'
         });
     });
+
+    it('should support date formats', function() {
+        var template = new Template({
+            body: {
+                date_iso: '{{date(request.body.date, "iso")}}',
+                date_rfc822: '{{date(request.body.date)}}'
+            }
+        });
+        var result = template.expand({
+            request: {
+                body: {
+                    date: '1234'
+                }
+            }
+        });
+        assert.deepEqual(result, {
+            body: {
+                date_iso: '1970-01-01T00:00:01.234Z',
+                date_rfc822: 'Thu, 01 Jan 1970 03:00:01 +0300'
+            }
+        });
+    });
 });

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -565,7 +565,7 @@ describe('Request template', function() {
         assert.deepEqual(result, {
             body: {
                 date_iso: '1970-01-01T00:00:01.234Z',
-                date_rfc822: 'Thu, 01 Jan 1970 03:00:01 +0300'
+                date_rfc822: require('rfc822-date')(new Date(1234))
             }
         });
     });


### PR DESCRIPTION
For change-propagation and support of the `If-Unmodified-Since` header in the request templates we need to have the ability to format dates in RFC822 format. Added a function for that. Also, function supports 'iso' format, and can be easily expanded in case it's needed.

cc @wikimedia/services 
