### PR TITLE
Improve date parsing in the formatting utility

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -116,13 +116,10 @@ var globalMethods = {
         if (!isValidDate(date)) {
             var origDate = date;
 
-            if (typeof date === 'string') {
+            if (typeof date === 'string' && !Number.isNaN(date)) {
                 // It's a string, but may be it's just a stringified timestamp.
                 // Check if it actually is.
-                var tempNumDate = parseInt(date);
-                if (!Number.isNaN(tempNumDate)) {
-                    date = tempNumDate;
-                }
+                date = parseInt(date);
             }
             date = new Date(date);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`parseInt` actually parses out a number from a string even if it contains non-numeric symbols.
`isNan` is doing more what we want there.

cc @wikimedia/services 
