### PR TITLE
Allow the method to be templated as well; release v0.4.5

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -149,9 +149,9 @@ function printableValue(value) {
                 newMethods[method] = '<' + val[method].name + '>';
             });
             res.methods = newMethods;
-        // Omit the specRoot, as it tends to be huge & contains reference
-        // circles.
         } else if (key !== 'specRoot') {
+            // Omit the specRoot, as it tends to be huge & contains reference
+            // circles.
             res[key] = val;
         }
     });

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -364,8 +364,6 @@ function Template(origSpec, globalsInit) {
             if (part === 'uri') {
                 globals._uri = createURIResolver(spec.uri, globals);
                 spec.uri = 'rc.g._uri(c)';
-            } else if (part === 'method') {
-                spec.method = "'" + (spec.method || 'get') + "'";
             } else {
                 spec[part] = replaceComplexTemplates(part, spec[part], globals);
             }
@@ -416,6 +414,10 @@ function Template(origSpec, globalsInit) {
         }
         var ret = res;
         res = null;
+        // ensure a reasonable fallback for ret.method
+        if (ret && ret.hasOwnProperty('method')) {
+            ret.method = ret.method || 'get';
+        }
         return ret;
     };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {
@@ -20,23 +20,23 @@
     "restbase"
   ],
   "author": "Gabriel Wicke <gwicke@wikimedia.org>",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/gwicke/swagger-router/issues"
   },
   "dependencies": {
-    "bluebird": "^3.1.1",
-    "core-js": "^2.0.3",
-    "js-yaml": "^3.5.2",
+    "bluebird": "^3.4.0",
+    "core-js": "^2.4.0",
+    "js-yaml": "^3.6.1",
     "tassembly": "^0.2.3",
     "template-expression-compiler": "^0.1.8"
   },
   "devDependencies": {
-    "mocha": "^2.3.4",
-    "mocha-jshint": "^2.2.6",
-    "istanbul": "^0.4.2",
-    "mocha-lcov-reporter": "^1.0.0",
-    "coveralls": "^2.11.6",
-    "mocha-jscs": "^4.0.0"
+    "mocha": "^2.5.3",
+    "mocha-jshint": "^2.3.1",
+    "istanbul": "^0.4.3",
+    "mocha-lcov-reporter": "^1.2.0",
+    "coveralls": "^2.11.9",
+    "mocha-jscs": "^5.0.0"
   }
 }

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -225,6 +225,17 @@ describe('Request template', function() {
         assert.deepEqual(template.expand({request:request}).uri, '/path/test/a');
     });
 
+    it('allows req.method to be templated', function() {
+        var template = new Template({
+            uri: '/foo/bar/baz',
+            method: '{{request.method}}'
+        });
+        var evalWithMethod = template.expand({ request: { method: 'post' } });
+        assert.deepEqual(evalWithMethod.method, 'post');
+        var evalWithoutMethod = template.expand({ request: {} });
+        assert.deepEqual(evalWithoutMethod.method, 'get');
+    });
+
     it('supports default values in req templates', function() {
         var template = new Template({
             uri: '/path/{default(request.body.test, "foo/bar")}',


### PR DESCRIPTION
Allowing the request method to be templated as well can come in handy in
situations where the request method is not known a priori. This is
needed by the service-template in which we want to create a generalised
approach to making requests to RESTBase.

Note that this change is 100% backwards-compatible in that it provides
'get' as the fall-back method and does not alter the return object if
the `mathod` field has not been specified in the template.
