### PR TITLE
Convert all URI path segments to strings & release v0.4.6

### DIFF
--- a/lib/uri.js
+++ b/lib/uri.js
@@ -27,6 +27,12 @@ function URI(uri, params, asPattern) {
         }
         this.path = utils.parsePath(uri, asPattern);
     } else if (Array.isArray(uri)) {
+        if (!asPattern) {
+            // Ensure that all path segments are strings
+            for (var i = 0; i < uri.length; i++) {
+                uri[i] = '' + uri[i];
+            }
+        }
         this.path = uri;
     } else if (uri && uri.constructor === URI) {
         this.protoHost = uri.protoHost;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/uri.js
+++ b/test/features/uri.js
@@ -93,14 +93,14 @@ describe('URI', function() {
     it('append a suffix path', function() {
         var baseURI = new URI('/{domain:test.com}/v1', {}, true);
         var suffix = new URI('/page/{title}', {}, true);
-        var uri = new URI(baseURI.path.concat(suffix.path), {title: 'foo'});
+        var uri = new URI(baseURI.path.concat(suffix.path), {title: 'foo'}, true);
         deepEqual(uri.toString(), '/test.com/v1/page/foo', {}, true);
         deepEqual(uri.expand().path, ['test.com', 'v1', 'page', 'foo']);
     });
 
     it('remove a suffix path', function() {
         var basePath = new URI('/{domain:test.com}/v1/page/{title}', {}, true).path;
-        var uri = new URI(basePath.slice(0, basePath.length - 2));
+        var uri = new URI(basePath.slice(0, basePath.length - 2), {}, true);
         deepEqual(uri.toString(), '/test.com/v1');
     });
 


### PR DESCRIPTION
We repeatedly ran into mysterious 'route not found' issues, which were caused
by non-string elements being passed in a `path` parameter to the `URI`
constructor. This issue frequently happens when processing `revision`
parameters, and leads to very subtle failures.

The work-around so far has been to manually make sure that each path segment
is converted to a string, before constructing the URI. This is error-prone and
ugly.

This patch addresses this by always converting UI path parameters to strings,
unless the `asPattern` flag is supplied. The change is simple, and the
performance impact should be minimal. In a benchmark, converting a
four-element array to strings takes about 0.000058ms, so the performance
impact of this change should be below noise level.
