### PR TITLE
Added support for transforming the timestamp to timeUUID

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,7 +4,7 @@ const URI = require('./uri');
 const TAssembly = require('tassembly');
 const expressionCompiler = require('template-expression-compiler');
 const utils = require('./utils');
-const TimeUUID = require('cassandra-uuid');
+const TimeUUID = require('cassandra-uuid').TimeUuid;
 
 const compilerOptions = {
     ctxMap: {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -308,7 +308,7 @@ function replaceComplexTemplates(part, subSpec, globals) {
     } else if (Array.isArray(subSpec)) {
         return subSpec.map((elem) => replaceComplexTemplates(part, elem, globals));
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
-        if (/\{[^\}]+\}/.test(subSpec)) {
+        if (/\{[^}]+\}/.test(subSpec)) {
             // There is a template, now we need to check it for special stuff we replace
             const tAssemblyTemplates = splitAndPrepareTAssemblyTemplate(subSpec, { part });
             if (tAssemblyTemplates.length === 1

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -140,6 +140,10 @@ const globalMethods = {
         /* eslint-enable indent */
     },
 
+    timeuuid() {
+        return new TimeUUID().toString();
+    },
+
     // Private helpers
     _optionalPath(element) {
         if (element !== undefined) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,6 +4,7 @@ const URI = require('./uri');
 const TAssembly = require('tassembly');
 const expressionCompiler = require('template-expression-compiler');
 const utils = require('./utils');
+const TimeUUID = require('cassandra-uuid');
 
 const compilerOptions = {
     ctxMap: {
@@ -131,6 +132,8 @@ const globalMethods = {
                 return utils.toRFC822Date(date);
             case 'iso':
                 return date.toISOString();
+            case 'timeuuid':
+                return TimeUUID.fromDate(date).toString();
             default:
                 throw new Error(`Unsupported date format: ${format}`);
         }

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -22,7 +22,7 @@ class URI {
         this._pathMetadata = {};
 
         if (typeof uri === 'string') {
-            const protoHostMatch = /^[^\/]+:(?:\/\/)?[^\/]+/.exec(uri);
+            const protoHostMatch = /^[^/]+:(?:\/\/)?[^/]+/.exec(uri);
             if (protoHostMatch) {
                 this.protoHost = protoHostMatch[0];
                 uri = uri.substring(this.protoHost.length);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ function robustDecodeURIComponent(uri) {
 // ({pattern} or {+pattern})|({/pattern})
 // jscs:disable
 /* eslint-disable max-len */
-const splitRe = /(\/)(?:\{([\+])?([^:\}\/]+)(?::([^}]+))?\}|([^\/\{]*))|(?:{([\/\+]))([^:\}\/]+)(?::([^}]+))?\}/g;
+const splitRe = /(\/)(?:\{([+])?([^:}/]+)(?::([^}]+))?}|([^/{]*))|(?:{([/+]))([^:}/]+)(?::([^}]+))?}/g;
 /* eslint-enable max-len */
 // jscs:enable
 function parsePattern(pattern) {
@@ -99,7 +99,7 @@ const unescapes = {
  */
 utils.encodeReserved = (string) => {
     const res = encodeURI(string);
-    if (!/[\[\]%]/.test(string)) {
+    if (!/[[\]%]/.test(string)) {
         return res;
     } else {
         // Un-escape [ and ] (which are legal in RFC6570), and un-do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,8 @@
     "bluebird": "^3.4.0",
     "js-yaml": "^3.6.1",
     "tassembly": "^0.2.3",
-    "template-expression-compiler": "^0.1.8"
+    "template-expression-compiler": "^0.1.8",
+    "cassandra-uuid": "^0.0.2"
   },
   "devDependencies": {
     "mocha": "^3.1.0",


### PR DESCRIPTION
Right now our summary endpoint content has the etag header that doesn't contain the revision number. We want to add rev id to the `ETag`, so we will generate it within the spec, so we need to convert the timestamp to the timeuuid.

We need a proper ETag for access control.

cc @wikimedia/services 