### PR TITLE
Fix handling of wildcard route requests ending in slash; v0.5.4

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -67,9 +67,8 @@ class Node {
         if (segment.constructor === String) {
             // Fast path
             let res = this._children[_keyPrefix + segment];
-            if (!res && segment !== '') {
-                // Fall back to the wildcard match, but only if the segment is
-                // non-empty.
+            if (!res) {
+                // Fall back to the wildcard match.
                 res = this._children['*'];
                 if (!res && this._children['**']) {
                     res = this._children['**'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/router.js
+++ b/test/features/router.js
@@ -262,9 +262,10 @@ var expectations = {
     '/en.wikipedia.org/v1/optional/': {
         params: {
             domain: 'en.wikipedia.org',
+            path: '',
             _ls: []
         },
-        value: null,
+        value: '/optional/{+path}',
         permissions: [],
         filters: []
     },
@@ -273,6 +274,16 @@ var expectations = {
         params: {
             domain: 'en.wikipedia.org',
             path: 'path'
+        },
+        permissions: [],
+        filters: []
+    },
+    '/en.wikipedia.org/v1/optional/path/': {
+        value: '/optional/{+path}',
+        params: {
+            domain: 'en.wikipedia.org',
+            path: 'path/',
+            _ls: []
         },
         permissions: [],
         filters: []


### PR DESCRIPTION
A wildcard match like /some{/foo} or /some/{+bar} should match even if
the optional component is empty (ex: request for /some/). {+bar} should
also match arbitrary paths ending on a slash (ex: /some/path/).