### PR TITLE
Add meta namespace for annotations; v0.5.5

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -44,9 +44,29 @@ class Node {
         this._parent = null;
     }
 
+    /**
+     * Register a child with a node.
+     *
+     * @param {string|object} key: One of
+     *   - A string representing a fixed path segment.
+     *   - A meta key of the format { type: 'meta', name: 'someName' }. This
+     *   is used to attach annotations in the tree that won't interfere with
+     *   normal routing lookups.
+     *   - A named path segment with a fixed value. This will be bound to a
+     *   parameter of the given name. Structure:
+     *   { name: 'someParamName', pattern: 'fixed_path_value' }
+     *   - A raw wildcard path segment matching one or more arbitrary path
+     *   segments: { name: 'someParamName', modifier: '+' }
+     *   - Another wildcard match consuming a single path segment:
+     *   { name: 'someParamName' }
+     * @param {Node} child, the child node to register.
+     * @return undefined
+     */
     setChild(key, child) {
         if (key.constructor === String) {
             this._children[_keyPrefix + key] = child;
+        } else if (key.type === 'meta') {
+            this._children[`meta_${key.name}`] = child;
         } else if (key.name && key.pattern
                 && key.modifier !== '+'
                 && key.pattern.constructor === String) {
@@ -63,6 +83,16 @@ class Node {
         }
     }
 
+    /**
+     * Look up a child in a node.
+     *
+     * @param {string|object} segment, one of
+     * - A string,
+     * - Pattern match objects as described in @setChild.
+     * @param {object} params, an accumulator object used to build up
+     * parameters encountered during the lookup process.
+     * @return {null|Node}
+     */
     getChild(segment, params) {
         if (segment.constructor === String) {
             // Fast path
@@ -94,6 +124,8 @@ class Node {
 
             // Fall-back cases for internal use during tree construction. These cases
             // are never used for actual routing.
+        } else if (segment.type === 'meta') {
+            return this._children[`meta_${segment.name}`];
         } else if (segment.pattern) {
             // Unwrap the pattern
             return this.getChild(segment.pattern, params);

--- a/lib/router.js
+++ b/lib/router.js
@@ -121,7 +121,7 @@ class Router {
         if (node || prevNode && path[path.length - 1] === '') {
             if (path[path.length - 1] === '') {
                 // Pass in a listing
-                params._ls = prevNode.keys();
+                params._ls = prevNode.keys().filter((key) => !/^meta_/.test(key));
             }
             return {
                 params,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/node.js
+++ b/test/features/node.js
@@ -1,0 +1,17 @@
+'use strict';
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+const deepEqual = require('assert').deepEqual;
+const Node = require('../../lib/node');
+
+
+describe('meta', () => {
+    const n = new Node();
+    const testKey = { type: 'meta', name: 'apiRoot' };
+    const testValue = { foo: 'bar' };
+    n.setChild(testKey, new Node(testValue));
+    deepEqual(n.getChild(testKey).value, testValue);
+    deepEqual(n.getChild(''), null);
+});
+


### PR DESCRIPTION
So far we used the magic '' node (URL ending in slash) to attach
metadata like API specs. Since we used a regular path, requests for /
would match this metadata node, despite it not necessarily having any
handlers. As a result, handlers registered for a wildcard (ex:
`{+path}`) were never reached.

This patch avoids this interference by separating metadata out into a
separate 'meta' lookup level. At the node level, this is represented by
the use of the 'meta_' prefix. As a result, regular lookups for URLs
ending in a slash do not match metadata-only nodes any more, which means
that wildcard handlers can kick in as expected. Among other things, this
makes it possible to register wildcard handlers at the API root, such as
`/{+path}`.