### PR TITLE
Added a 'decode' function the reqTemplate

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -144,6 +144,16 @@ const globalMethods = {
         return new TimeUUID().toString();
     },
 
+    /**
+     * Applies `decodeURIComponent` to the provided string
+     *
+     * @param data {string} data needed to be decoded.
+     * @returns {string}
+     */
+    decode(data) {
+        return decodeURIComponent(data)
+    },
+
     // Private helpers
     _optionalPath(element) {
         if (element !== undefined) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -151,7 +151,10 @@ const globalMethods = {
      * @returns {string}
      */
     decode(data) {
-        return decodeURIComponent(data)
+        if (typeof data !== 'string') {
+            return data;
+        }
+        return decodeURIComponent(data);
     },
 
     // Private helpers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order to use MW-specific title encoding in the EventBus infrastructure, sometimes we need to reencode the titles by doing `encodeURIComponent(decodeURIComponent(title))`  in the template. Single curly braces handle encoding for us, but for decoding we need a function.

This is a stepping stone for getting to use `wfUrlencode` in the EventBus extension. Of course reencoding takes some CPU, but it's very rarely needed since most of the time we use the un-encoded title from the event contents.

Bug: https://phabricator.wikimedia.org/T155066