### PR TITLE
Expose the 'specPath' when looking up

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -93,6 +93,7 @@ class Router {
         let prevNode;
         let permissions = [];
         let filters = [];
+        let specPath = [];
         for (let i = 0; i < path.length; i++) {
             if (!node || !node.getChild) {
                 return null;
@@ -107,6 +108,7 @@ class Router {
                 }
             }
             node = node.getChild(path[i], params);
+            specPath.push(node._paramName || path[i]);
         }
 
         if (node && node.value) {
@@ -127,7 +129,8 @@ class Router {
                 params,
                 value: (node && node.value || null),
                 permissions,
-                filters
+                filters,
+                specPath
             };
         } else {
             return null;
@@ -162,7 +165,8 @@ class Router {
                 params: res.params,
                 value: res.value,
                 permissions: res.permissions,
-                filters: res.filters
+                filters: res.filters,
+                specPath: res.specPath
             };
         } else {
             return res;


### PR DESCRIPTION
I'm prototyping a change-prop  based solution to collect statistics on Varnish level for requests to RESTBase and need this to happen first.

Bug: T122245