### PR TITLE
Support multi-line YAML syntax for expressions; v0.6.0

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -322,6 +322,16 @@ function replaceComplexTemplates(part, subSpec, globals) {
         return subSpec.map((elem) => replaceComplexTemplates(part, elem, globals));
     } else if (subSpec && subSpec.constructor === String || subSpec === '') {
         if (/\{[^}]+\}/.test(subSpec)) {
+            // Strip trailing newlines, so that we can use yaml multi-line
+            // syntax like this:
+            // someKey: >
+            //   {{ merge ({
+            //        "someKey": "foo",
+            //        "otherKey": "bar"
+            //      }, options }}
+            if (/^\{[\w\W]*\}\n$/m.test(subSpec)) {
+                subSpec = subSpec.replace(/\n$/, '');
+            }
             // There is a template, now we need to check it for special stuff we replace
             const tAssemblyTemplates = splitAndPrepareTAssemblyTemplate(subSpec, { part });
             if (tAssemblyTemplates.length === 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/reqTemplate.js
+++ b/test/features/reqTemplate.js
@@ -310,6 +310,19 @@ describe('Request template', function() {
         assert.deepEqual(result, request);
     });
 
+    it('should support string templates with trailing newlines', function() {
+        var template = new Template('{{request}}\n');
+        var request = {
+            method: 'get',
+            uri: 'test.com',
+            body: {
+                field: 'value'
+            }
+        };
+        var result = template.expand({ request: request });
+        assert.deepEqual(result, request);
+    });
+
     it('should support short notation in string templates', function() {
         var template = new Template('{{request}}');
         var request = {


### PR DESCRIPTION
Our templated expressions can become quite hard to read when they
contain merge functions and more complex object literals on a single
line. While YAML supports multi-line syntax in general, we have not been
able to use this so far. The YAML parser we use emits a trailing newline
for multi-line strings, which throws off the expression parser.

This patch addresses this issue by conservatively stripping a single
trailing newline if the template string looks like a templated
expression. As a result, we will be able to properly format longer
expressions for readability, using YAML's built-in multi-line syntax.