### PR TITLE
Fix route parsing when concrete and wildcard paths overlap

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -91,13 +91,15 @@ class Node {
      * - Pattern match objects as described in @setChild.
      * @param {object} params, an accumulator object used to build up
      * parameters encountered during the lookup process.
+     * @param {bool} exact, whether to do an exact segment lookup
+     * (where * and ** only match themselves)
      * @return {null|Node}
      */
-    getChild(segment, params) {
+    getChild(segment, params, exact) {
         if (segment.constructor === String) {
             // Fast path
             let res = this._children[_keyPrefix + segment];
-            if (!res) {
+            if (!res && !exact) {
                 // Fall back to the wildcard match.
                 res = this._children['*'];
                 if (!res && this._children['**']) {
@@ -128,7 +130,7 @@ class Node {
             return this._children[`meta_${segment.name}`];
         } else if (segment.pattern) {
             // Unwrap the pattern
-            return this.getChild(segment.pattern, params);
+            return this.getChild(segment.pattern, params, exact);
         } else if (this._children['*']
         && this._children['*']._paramName === segment.name) {
             // XXX: also compare modifier!


### PR DESCRIPTION
When building a node tree from a set of paths, the normal
child lookup was used, where concrete path segments can match
wildcards. This resulted in unrelated paths being incorrectly
coalesced (or not, depengin on path order). E.g.

    path 1: /{var}/bar
    path 2: /foo/baz
    Expected: { foo: { baz: {} }, '*': { bar: {} } }
    Actual: { '*': { bar: {}, baz: {} } }

Use exact child lookup when building the tree to avoid this.

The hyperswitch part of the patch is wikimedia/hyperswitch/81.