### PR TITLE
Add tests for overlap handling; v0.7.1

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -73,7 +73,7 @@ class Router {
     _extend(path, node, value) {
         const params = {};
         for (let i = 0; i < path.length; i++) {
-            const nextNode = node.getChild(path[i], params);
+            const nextNode = node.getChild(path[i], params, true);
             if (!nextNode || !nextNode.getChild) {
                 // Found our extension point
                 node.setChild(path[i], this._buildTree(path.slice(i + 1), value));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-router",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An efficient swagger 2 based router with support for multiple APIs. For use in RESTBase.",
   "main": "index.js",
   "scripts": {

--- a/test/features/router.js
+++ b/test/features/router.js
@@ -29,7 +29,9 @@ var specs = [
             // Modifiers: optional path segments
             '/simple/{templated}{/path}': '/simple/{templated}{/path}',
             '/several{/optional}{/path}{+segments}': '/several{/optional}{/path}{+segments}',
-            '/optional/{+path}': '/optional/{+path}'
+            '/optional/{+path}': '/optional/{+path}',
+            '/overlapping/{wildcard}': '/overlapping/{wildcard}',
+            '/overlapping/concrete': '/overlapping/concrete',
         }
     }
 ];
@@ -293,6 +295,25 @@ var expectations = {
         params: {
             domain: 'en.wikipedia.org',
             path: 'path/bits'
+        },
+        permissions: [],
+        filters: []
+    },
+
+    // Overlapping paths
+    '/en.wikipedia.org/v1/overlapping/concrete': {
+        value: '/overlapping/concrete',
+        params: {
+            domain: 'en.wikipedia.org',
+        },
+        permissions: [],
+        filters: []
+    },
+    '/en.wikipedia.org/v1/overlapping/other': {
+        value: '/overlapping/{wildcard}',
+        params: {
+            domain: 'en.wikipedia.org',
+            wildcard: 'other',
         },
         permissions: [],
         filters: []


### PR DESCRIPTION
- Set the 'exact' flag while building the tree.
- Add tests for overlapping path handling.
- Release v0.7.1